### PR TITLE
Protocol fixes from red-team review

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -80,10 +80,17 @@ The default is `jsonl-short` — a concise view of Claude's responses without to
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `size` | integer ≥ 1 | No | Number of slots. Falls back to `config.json` if omitted. |
+| `noRestore` | boolean | No | Skip restoring previously live sessions (default false). |
 
 **Response:** `{ type: "pool", pool }` — full pool state after init.
 
-**Behavior:** Creates a new pool with `size` pre-warmed Claude sessions. Reads flags from `config.json`. Errors if pool already initialized (sessions are running). Each slot spawns a Claude process with the configured flags. Sessions start in internal `fresh` state (API won't expose this — they appear once they reach a visible state). Updates `pools.json` registry.
+**Behavior:** Initializes the pool daemon. Reads flags from `config.json`. Errors if pool already initialized (sessions are running). Updates `pools.json` registry.
+
+If previous session state exists (from a prior run that was destroyed or crashed), `init` restores sessions that were **live** (idle, typing, or processing) when the pool last shut down. These sessions are loaded via `/resume` into available slots. Sessions that were already offloaded, dead, error, or archived remain in their prior state. If there are more sessions to restore than `size` slots, excess sessions stay offloaded and can be loaded later via `followup` or `pin`.
+
+If `noRestore: true`, previous session state is ignored — all slots are filled with fresh pre-warmed sessions instead.
+
+If no previous state exists (first-time init), all slots get fresh pre-warmed sessions regardless of `noRestore`.
 
 ---
 

--- a/schema/protocol.json
+++ b/schema/protocol.json
@@ -185,7 +185,7 @@
     },
 
     "init": {
-      "description": "Initialize pool. Size optional (falls back to config). Flags from config.json.",
+      "description": "Initialize pool. Restores previously live sessions by default. Size optional (falls back to config).",
       "request": {
         "type": "object",
         "properties": {
@@ -195,6 +195,11 @@
             "type": "integer",
             "minimum": 1,
             "description": "Slot count. Falls back to config.json if omitted."
+          },
+          "noRestore": {
+            "type": "boolean",
+            "default": false,
+            "description": "Skip restoring previously live sessions. All slots get fresh pre-warmed sessions."
           }
         },
         "required": ["type"]


### PR DESCRIPTION
## Summary

- **followup**: add `status` to response (matches `start` response shape)
- **wait**: error immediately when no sessionId and no owned busy sessions
- **resize**: rewrite to lazy downsizing — enqueues kill-slot tokens at front of queue, processing sessions finish naturally, pinned sessions never evicted
- **destroy**: require `confirm: true` field as safety guard
- **input**: explicitly list all no-terminal error states (dead/error/archived)
- **offload**: remove `/clear` implementation detail from public API doc
- **followup**: remove incorrect "Claude UUID may change" claim
- **result**: remove command entirely — `capture` covers all use cases

## Test plan

- [ ] Verify protocol.md reads coherently end-to-end
- [ ] Verify schema/protocol.json is valid and consistent with protocol.md