### PR TITLE
Build test binaries once via TestMain

### DIFF
--- a/tests/cli/helpers_test.go
+++ b/tests/cli/helpers_test.go
@@ -19,7 +19,62 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/EliasSchlie/claude-pool/tests/testutil"
 )
+
+// Built once by TestMain and shared across all test functions.
+var (
+	daemonBinPath string
+	cliBinPath    string
+)
+
+func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "claude-pool-cli-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	repoRoot := testutil.FindRepoRoot()
+
+	// Build daemon and CLI in parallel — they're independent
+	daemonBinPath = filepath.Join(tmpDir, "claude-pool")
+	cliBinPath = filepath.Join(tmpDir, "claude-pool-cli")
+
+	type buildResult struct {
+		name string
+		out  []byte
+		err  error
+	}
+	ch := make(chan buildResult, 2)
+
+	for _, target := range []struct{ name, bin, pkg string }{
+		{"daemon", daemonBinPath, "./cmd/claude-pool"},
+		{"CLI", cliBinPath, "./cmd/claude-pool-cli"},
+	} {
+		target := target
+		go func() {
+			build := exec.Command("go", "build", "-o", target.bin, target.pkg)
+			build.Dir = repoRoot
+			out, err := build.CombinedOutput()
+			ch <- buildResult{target.name, out, err}
+		}()
+	}
+
+	for i := 0; i < 2; i++ {
+		r := <-ch
+		if r.err != nil {
+			os.RemoveAll(tmpDir)
+			fmt.Fprintf(os.Stderr, "failed to build %s: %v\n%s\n", r.name, r.err, r.out)
+			os.Exit(1)
+		}
+	}
+
+	code := m.Run()
+	os.RemoveAll(tmpDir)
+	os.Exit(code)
+}
 
 type Msg = map[string]any
 
@@ -27,7 +82,6 @@ type cliPool struct {
 	t          *testing.T
 	poolDir    string
 	socketPath string
-	daemonBin  string
 	cliBin     string
 	daemon     *exec.Cmd
 	poolName   string
@@ -39,31 +93,11 @@ type cmdResult struct {
 	ExitCode int
 }
 
-// setupCLIPool builds both binaries, starts the daemon, calls init via socket,
-// and returns a cliPool ready for CLI commands.
+// setupCLIPool starts the daemon, calls init via socket, and returns a cliPool
+// ready for CLI commands. Binaries are built once by TestMain.
 func setupCLIPool(t *testing.T, size int) *cliPool {
 	t.Helper()
 
-	repoRoot := findRepoRoot(t)
-
-	// Build daemon binary
-	binDir := t.TempDir()
-	daemonBin := filepath.Join(binDir, "claude-pool")
-	build := exec.Command("go", "build", "-o", daemonBin, "./cmd/claude-pool")
-	build.Dir = repoRoot
-	if out, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build daemon: %v\n%s", err, out)
-	}
-
-	// Build CLI binary
-	cliBin := filepath.Join(binDir, "claude-pool-cli")
-	build = exec.Command("go", "build", "-o", cliBin, "./cmd/claude-pool-cli")
-	build.Dir = repoRoot
-	if out, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build CLI: %v\n%s", err, out)
-	}
-
-	// Create temp pool directory and registry
 	poolDir := t.TempDir()
 	socketPath := filepath.Join(poolDir, "api.sock")
 	poolName := "test"
@@ -91,7 +125,7 @@ func setupCLIPool(t *testing.T, size int) *cliPool {
 	}
 
 	// Start daemon
-	daemon := exec.Command(daemonBin, "--pool-dir", poolDir)
+	daemon := exec.Command(daemonBinPath, "--pool-dir", poolDir)
 	daemon.Stdout = os.Stdout
 	daemon.Stderr = os.Stderr
 	if err := daemon.Start(); err != nil {
@@ -115,8 +149,7 @@ func setupCLIPool(t *testing.T, size int) *cliPool {
 		t:          t,
 		poolDir:    poolDir,
 		socketPath: socketPath,
-		daemonBin:  daemonBin,
-		cliBin:     cliBin,
+		cliBin:     cliBinPath,
 		daemon:     daemon,
 		poolName:   poolName,
 	}
@@ -247,24 +280,6 @@ func (p *cliPool) runInSessionJSON(sessionID string, args ...string) Msg {
 		p.t.Fatalf("failed to parse CLI JSON output: %v\nstdout: %s", err, result.Stdout)
 	}
 	return msg
-}
-
-func findRepoRoot(t *testing.T) string {
-	t.Helper()
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("could not find repo root (no go.mod)")
-		}
-		dir = parent
-	}
 }
 
 func strVal(m map[string]any, key string) string {

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -25,7 +25,28 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/EliasSchlie/claude-pool/tests/testutil"
 )
+
+// daemonBinPath is built once by TestMain and shared across all test functions.
+var daemonBinPath string
+
+func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "claude-pool-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	repoRoot := testutil.FindRepoRoot()
+	daemonBinPath = filepath.Join(tmpDir, "claude-pool")
+	testutil.BuildBinary(repoRoot, daemonBinPath, "./cmd/claude-pool")
+
+	code := m.Run()
+	os.RemoveAll(tmpDir)
+	os.Exit(code)
+}
 
 // --------------------------------------------------------------------
 // JSON message types
@@ -140,19 +161,12 @@ func setupPool(t *testing.T, size int) *testPool {
 	return p
 }
 
-// setupDaemon builds the daemon binary, starts it with a temp pool directory,
-// and connects — but does NOT call init. Use this when the test flow needs to
-// control init timing (e.g., pool_test.go tests ping/config before init).
+// setupDaemon starts a daemon with a temp pool directory and connects — but does
+// NOT call init. Use this when the test flow needs to control init timing
+// (e.g., pool_test.go tests ping/config before init).
+// The daemon binary is built once by TestMain and shared across all tests.
 func setupDaemon(t *testing.T, size int) *testPool {
 	t.Helper()
-
-	binDir := t.TempDir()
-	binPath := filepath.Join(binDir, "claude-pool")
-	build := exec.Command("go", "build", "-o", binPath, "./cmd/claude-pool")
-	build.Dir = findRepoRoot(t)
-	if out, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("failed to build daemon: %v\n%s", err, out)
-	}
 
 	poolDir := t.TempDir()
 	socketPath := filepath.Join(poolDir, "api.sock")
@@ -170,7 +184,7 @@ func setupDaemon(t *testing.T, size int) *testPool {
 	p := &testPool{
 		t:          t,
 		dir:        poolDir,
-		binPath:    binPath,
+		binPath:    daemonBinPath,
 		socketPath: socketPath,
 	}
 
@@ -230,25 +244,6 @@ func (p *testPool) startDaemon() {
 	}
 	p.conn = conn
 	p.scanner = bufio.NewScanner(conn)
-}
-
-// findRepoRoot walks up from cwd to find go.mod.
-func findRepoRoot(t *testing.T) string {
-	t.Helper()
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("could not find repo root (no go.mod)")
-		}
-		dir = parent
-	}
 }
 
 // --------------------------------------------------------------------

--- a/tests/testutil/testutil.go
+++ b/tests/testutil/testutil.go
@@ -1,0 +1,41 @@
+// Package testutil provides shared helpers for test infrastructure.
+// Used by TestMain in each test package — not for use inside individual tests.
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// FindRepoRoot walks up from cwd to find the directory containing go.mod.
+func FindRepoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "getwd: %v\n", err)
+		os.Exit(1)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			fmt.Fprintf(os.Stderr, "could not find repo root (no go.mod)\n")
+			os.Exit(1)
+		}
+		dir = parent
+	}
+}
+
+// BuildBinary runs `go build` for the given package and writes the binary to outputPath.
+// Exits the process on failure (intended for TestMain, not individual tests).
+func BuildBinary(repoRoot, outputPath, pkg string) {
+	build := exec.Command("go", "build", "-o", outputPath, pkg)
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build %s: %v\n%s\n", pkg, err, out)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary

- Extract `tests/testutil/` package with shared `FindRepoRoot()` and `BuildBinary()` helpers
- Both integration and CLI test packages now build binaries once in `TestMain` instead of per test function (~8 redundant `go build` calls eliminated)
- CLI `TestMain` builds daemon + CLI binaries in parallel
- Fix `defer` + `os.Exit` bug where temp dirs were never cleaned up

## Test plan

- [ ] `go vet ./tests/...` passes
- [ ] `go test ./tests/integration/ -v -run TestPool -timeout 5m` still works
- [ ] `go test ./tests/cli/ -v -run TestCLI -timeout 5m` still works