### PR TITLE
Tighten integration test timeouts

### DIFF
--- a/tests/cli/helpers_test.go
+++ b/tests/cli/helpers_test.go
@@ -175,7 +175,7 @@ func setupCLIPool(t *testing.T, size int) *cliPool {
 	initMsg, _ := json.Marshal(Msg{"type": "init", "size": size})
 	conn.Write(append(initMsg, '\n'))
 	scanner := bufio.NewScanner(conn)
-	conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
 	if scanner.Scan() {
 		var resp Msg
 		json.Unmarshal(scanner.Bytes(), &resp)

--- a/tests/integration/attach_test.go
+++ b/tests/integration/attach_test.go
@@ -1,0 +1,191 @@
+package integration
+
+// TestAttach — Attach pipe workflow flow
+//
+// Pool size: 2
+//
+// This flow tests raw PTY attach: connecting to a session's terminal,
+// typing detection, submitting prompts through the pipe, API followup
+// while attached, and pipe lifecycle (offload closes pipe, re-attach
+// after reload).
+//
+// Flow:
+//
+//   1.  "pin fresh session"
+//   2.  "attach to idle session"
+//   3.  "keystrokes detected as typing"
+//   4.  "clearing input returns to idle"
+//   5.  "submit via attach triggers processing and completes"
+//   6.  "followup via API while attached"
+//   7.  "offload closes attach pipe"
+//   8.  "attach fails on offloaded session"
+//   9.  "re-pin and re-attach after offload"
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestAttach(t *testing.T) {
+	pool := setupPool(t, 2)
+
+	var s1 string
+	var attachConn net.Conn
+
+	t.Run("pin fresh session", func(t *testing.T) {
+		resp := pool.send(Msg{"type": "pin"})
+		assertNotError(t, resp)
+		assertType(t, resp, "ok")
+
+		s1 = strVal(resp, "sessionId")
+		assertNonEmpty(t, "sessionId", s1)
+
+		pool.awaitStatus(s1, "idle", 30*time.Second)
+	})
+
+	t.Run("attach to idle session", func(t *testing.T) {
+		resp := pool.send(Msg{"type": "attach", "sessionId": s1})
+		assertNotError(t, resp)
+		assertType(t, resp, "attached")
+
+		socketPath := strVal(resp, "socketPath")
+		assertNonEmpty(t, "socketPath", socketPath)
+
+		var err error
+		attachConn, err = net.Dial("unix", socketPath)
+		if err != nil {
+			t.Fatalf("connect to attach socket: %v", err)
+		}
+		t.Cleanup(func() { attachConn.Close() })
+
+		drainAttach(attachConn)
+	})
+
+	t.Run("keystrokes detected as typing", func(t *testing.T) {
+		if _, err := attachConn.Write([]byte("hello")); err != nil {
+			t.Fatalf("write to attach socket: %v", err)
+		}
+
+		pool.awaitStatus(s1, "typing", 10*time.Second)
+	})
+
+	t.Run("clearing input returns to idle", func(t *testing.T) {
+		// Ctrl-U clears the input line
+		if _, err := attachConn.Write([]byte("\x15")); err != nil {
+			t.Fatalf("write Ctrl-U: %v", err)
+		}
+
+		pool.awaitStatus(s1, "idle", 10*time.Second)
+	})
+
+	t.Run("submit via attach triggers processing and completes", func(t *testing.T) {
+		if _, err := attachConn.Write([]byte("respond with exactly: attach-test-output\r")); err != nil {
+			t.Fatalf("write prompt: %v", err)
+		}
+
+		pool.awaitStatus(s1, "processing", 15*time.Second)
+		pool.awaitStatus(s1, "idle", 30*time.Second)
+
+		resp := pool.send(Msg{"type": "capture", "sessionId": s1, "format": "jsonl-last"})
+		assertNotError(t, resp)
+		assertContains(t, strVal(resp, "content"), "attach-test-output")
+	})
+
+	t.Run("followup via API while attached", func(t *testing.T) {
+		drainAttach(attachConn)
+
+		resp := pool.send(Msg{
+			"type": "followup", "sessionId": s1,
+			"prompt": "respond with exactly: followup-while-attached",
+		})
+		assertNotError(t, resp)
+
+		pool.awaitStatus(s1, "processing", 15*time.Second)
+
+		// Attach pipe should receive terminal output from the API-driven followup
+		buf := make([]byte, 8192)
+		attachConn.SetReadDeadline(time.Now().Add(30 * time.Second))
+		n, err := attachConn.Read(buf)
+		if err != nil {
+			t.Fatalf("attach pipe broke during API followup: %v", err)
+		}
+		if n == 0 {
+			t.Fatal("expected terminal output from followup on attach pipe")
+		}
+
+		pool.awaitStatus(s1, "idle", 30*time.Second)
+
+		captureResp := pool.send(Msg{"type": "capture", "sessionId": s1, "format": "jsonl-last"})
+		assertNotError(t, captureResp)
+		assertContains(t, strVal(captureResp, "content"), "followup-while-attached")
+	})
+
+	t.Run("offload closes attach pipe", func(t *testing.T) {
+		// Offload auto-unpins per protocol
+		resp := pool.send(Msg{"type": "offload", "sessionId": s1})
+		assertNotError(t, resp)
+
+		buf := make([]byte, 1)
+		attachConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		_, err := attachConn.Read(buf)
+		if err != io.EOF {
+			t.Fatalf("expected EOF after offload, got: %v", err)
+		}
+	})
+
+	t.Run("attach fails on offloaded session", func(t *testing.T) {
+		resp := pool.send(Msg{"type": "attach", "sessionId": s1})
+		assertError(t, resp)
+	})
+
+	t.Run("re-pin and re-attach after offload", func(t *testing.T) {
+		resp := pool.send(Msg{"type": "pin", "sessionId": s1})
+		assertNotError(t, resp)
+
+		pool.awaitStatus(s1, "idle", 30*time.Second)
+
+		attachResp := pool.send(Msg{"type": "attach", "sessionId": s1})
+		assertNotError(t, attachResp)
+		assertType(t, attachResp, "attached")
+
+		newPath := strVal(attachResp, "socketPath")
+		assertNonEmpty(t, "new socketPath", newPath)
+
+		newConn, err := net.Dial("unix", newPath)
+		if err != nil {
+			t.Fatalf("connect to new attach socket: %v", err)
+		}
+		defer newConn.Close()
+
+		// Verify pipe is alive by writing a character and reading the echo
+		if _, err := newConn.Write([]byte("x")); err != nil {
+			t.Fatalf("write to re-attached socket: %v", err)
+		}
+		buf := make([]byte, 4096)
+		newConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		n, err := newConn.Read(buf)
+		if err != nil {
+			t.Fatalf("read from re-attached socket: %v", err)
+		}
+		if n == 0 {
+			t.Fatal("expected output from re-attached session")
+		}
+
+		// Clean up typed character
+		newConn.Write([]byte("\x15"))
+	})
+}
+
+// drainAttach reads and discards any pending output from an attach pipe.
+func drainAttach(conn net.Conn) {
+	buf := make([]byte, 8192)
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	for {
+		_, err := conn.Read(buf)
+		if err != nil {
+			break
+		}
+	}
+}

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -255,7 +255,7 @@ func (p *testPool) startDaemon() {
 func (p *testPool) send(msg Msg) Msg {
 	p.t.Helper()
 	msg["id"] = int(p.nextID.Add(1))
-	return p.doSend(p.conn, p.scanner, msg, 30*time.Second)
+	return p.doSend(p.conn, p.scanner, msg, 10*time.Second)
 }
 
 // sendLong sends a message with a custom read timeout (for long-polling commands like wait).
@@ -281,7 +281,7 @@ func (p *testPool) doSend(conn net.Conn, scanner *bufio.Scanner, msg Msg, readTi
 	}
 	data = append(data, '\n')
 
-	conn.SetWriteDeadline(time.Now().Add(30 * time.Second))
+	conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 	if _, err := conn.Write(data); err != nil {
 		p.t.Fatalf("write: %v", err)
 	}
@@ -318,7 +318,7 @@ func (p *testPool) newConn() (net.Conn, *bufio.Scanner) {
 func (p *testPool) sendOn(conn net.Conn, scanner *bufio.Scanner, msg Msg) Msg {
 	p.t.Helper()
 	msg["id"] = int(p.nextID.Add(1))
-	return p.doSend(conn, scanner, msg, 30*time.Second)
+	return p.doSend(conn, scanner, msg, 10*time.Second)
 }
 
 // --------------------------------------------------------------------

--- a/tests/integration/offload_test.go
+++ b/tests/integration/offload_test.go
@@ -46,8 +46,8 @@ func TestOffload(t *testing.T) {
 		assertNotError(t, r2)
 		s2 = strVal(r2, "sessionId")
 
-		pool.awaitStatus(s1, "idle", 120*time.Second)
-		pool.awaitStatus(s2, "idle", 120*time.Second)
+		pool.awaitStatus(s1, "idle", 60*time.Second)
+		pool.awaitStatus(s2, "idle", 60*time.Second)
 	})
 
 	t.Run("offload idle session", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestOffload(t *testing.T) {
 
 	t.Run("offload non-idle errors", func(t *testing.T) {
 		pool.send(Msg{"type": "followup", "sessionId": s2, "prompt": "run the bash command: sleep 60"})
-		pool.awaitStatus(s2, "processing", 30*time.Second)
+		pool.awaitStatus(s2, "processing", 15*time.Second)
 
 		resp := pool.send(Msg{"type": "offload", "sessionId": s2})
 		assertError(t, resp)
@@ -109,7 +109,7 @@ func TestOffload(t *testing.T) {
 		assertNotError(t, resp)
 		assertType(t, resp, "started")
 
-		pool.awaitStatus(s1, "idle", 120*time.Second)
+		pool.awaitStatus(s1, "idle", 60*time.Second)
 
 		capture := pool.send(Msg{"type": "capture", "sessionId": s1})
 		assertContains(t, strVal(capture, "content"), "restored")
@@ -199,7 +199,7 @@ func TestOffload(t *testing.T) {
 
 	t.Run("archive stops active session first", func(t *testing.T) {
 		pool.send(Msg{"type": "followup", "sessionId": s2, "prompt": "run the bash command: sleep 60"})
-		pool.awaitStatus(s2, "processing", 30*time.Second)
+		pool.awaitStatus(s2, "processing", 15*time.Second)
 
 		resp := pool.send(Msg{"type": "archive", "sessionId": s2})
 		assertNotError(t, resp)

--- a/tests/integration/parent_child_test.go
+++ b/tests/integration/parent_child_test.go
@@ -45,7 +45,7 @@ func TestParentChild(t *testing.T) {
 		assertNotError(t, resp)
 		s1 = strVal(resp, "sessionId")
 
-		pool.awaitStatus(s1, "idle", 120*time.Second)
+		pool.awaitStatus(s1, "idle", 60*time.Second)
 
 		info := pool.send(Msg{"type": "info", "sessionId": s1})
 		session := parseSession(t, info["session"])
@@ -62,7 +62,7 @@ func TestParentChild(t *testing.T) {
 		assertNotError(t, resp)
 		s2 = strVal(resp, "sessionId")
 
-		pool.awaitStatus(s2, "idle", 120*time.Second)
+		pool.awaitStatus(s2, "idle", 60*time.Second)
 
 		info2 := pool.send(Msg{"type": "info", "sessionId": s2})
 		session2 := parseSession(t, info2["session"])
@@ -81,7 +81,7 @@ func TestParentChild(t *testing.T) {
 		assertNotError(t, resp)
 		s3 = strVal(resp, "sessionId")
 
-		pool.awaitStatus(s3, "idle", 120*time.Second)
+		pool.awaitStatus(s3, "idle", 60*time.Second)
 
 		info3 := pool.send(Msg{"type": "info", "sessionId": s3})
 		session3 := parseSession(t, info3["session"])
@@ -103,7 +103,7 @@ func TestParentChild(t *testing.T) {
 		assertNotError(t, resp)
 		s4 = strVal(resp, "sessionId")
 
-		pool.awaitStatus(s4, "idle", 120*time.Second)
+		pool.awaitStatus(s4, "idle", 60*time.Second)
 
 		info1 := pool.send(Msg{"type": "info", "sessionId": s1})
 		session1 := parseSession(t, info1["session"])

--- a/tests/integration/pool_test.go
+++ b/tests/integration/pool_test.go
@@ -97,7 +97,7 @@ func TestPool(t *testing.T) {
 		for _, raw := range sessions {
 			sm, _ := raw.(map[string]any)
 			sid := strVal(sm, "sessionId")
-			pool.awaitStatus(sid, "idle", 120*time.Second)
+			pool.awaitStatus(sid, "idle", 60*time.Second)
 		}
 
 		sm0, _ := sessions[0].(map[string]any)
@@ -152,25 +152,25 @@ func TestPool(t *testing.T) {
 			t.Fatalf("expected size 3 after resize, got %v", numVal(state, "size"))
 		}
 
-		pool.awaitIdleCount(3, 120*time.Second)
+		pool.awaitIdleCount(3, 60*time.Second)
 	})
 
 	t.Run("resize down to 1", func(t *testing.T) {
 		// Keep s1 processing so we can observe async slot reclamation
 		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "run the bash command: sleep 60"})
-		pool.awaitStatus(s1, "processing", 30*time.Second)
+		pool.awaitStatus(s1, "processing", 15*time.Second)
 
 		resp := pool.send(Msg{"type": "resize", "size": 1})
 		assertNotError(t, resp)
 
 		// Stop s1 so its slot can be reclaimed
 		pool.send(Msg{"type": "stop", "sessionId": s1})
-		pool.awaitPoolSize(1, 30*time.Second)
+		pool.awaitPoolSize(1, 15*time.Second)
 	})
 
 	t.Run("resize respects pins", func(t *testing.T) {
 		pool.send(Msg{"type": "resize", "size": 2})
-		pool.awaitIdleCount(2, 120*time.Second)
+		pool.awaitIdleCount(2, 60*time.Second)
 
 		// Identify current sessions
 		lsResp := pool.send(Msg{"type": "ls", "all": true})
@@ -185,7 +185,7 @@ func TestPool(t *testing.T) {
 		// Resize to 1 — the unpinned session should lose its slot
 		pool.send(Msg{"type": "resize", "size": 1})
 
-		pool.awaitPoolSize(1, 30*time.Second)
+		pool.awaitPoolSize(1, 15*time.Second)
 
 		// Verify the pinned session survived
 		infoResp := pool.send(Msg{"type": "info", "sessionId": pinned})
@@ -233,7 +233,7 @@ func TestPool(t *testing.T) {
 		for _, raw := range sessions {
 			sm, _ := raw.(map[string]any)
 			sid := strVal(sm, "sessionId")
-			pool.awaitStatus(sid, "idle", 120*time.Second)
+			pool.awaitStatus(sid, "idle", 60*time.Second)
 		}
 
 		// Session restoration is a contract — s1 must survive destroy+re-init
@@ -278,7 +278,7 @@ func TestPool(t *testing.T) {
 		for _, raw := range sessions {
 			sm, _ := raw.(map[string]any)
 			sid := strVal(sm, "sessionId")
-			pool.awaitStatus(sid, "idle", 120*time.Second)
+			pool.awaitStatus(sid, "idle", 60*time.Second)
 		}
 	})
 }

--- a/tests/integration/session_test.go
+++ b/tests/integration/session_test.go
@@ -65,8 +65,8 @@ func TestSession(t *testing.T) {
 
 	t.Run("wait returns result", func(t *testing.T) {
 		resp := pool.sendLong(
-			Msg{"type": "wait", "sessionId": s1, "timeout": 120000},
-			150*time.Second,
+			Msg{"type": "wait", "sessionId": s1, "timeout": 60000},
+			75*time.Second,
 		)
 		assertNotError(t, resp)
 		assertType(t, resp, "result")
@@ -115,8 +115,8 @@ func TestSession(t *testing.T) {
 		// (Claude sessions can only access local dirs, not system dirs like /tmp)
 		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "run these bash commands: mkdir -p cwd_test_dir && cd cwd_test_dir"})
 		pool.sendLong(
-			Msg{"type": "wait", "sessionId": s1, "timeout": 120000},
-			150*time.Second,
+			Msg{"type": "wait", "sessionId": s1, "timeout": 60000},
+			75*time.Second,
 		)
 
 		info = pool.send(Msg{"type": "info", "sessionId": s1})
@@ -200,8 +200,8 @@ func TestSession(t *testing.T) {
 		assertNonEmpty(t, "followup status", strVal(resp, "status"))
 
 		waitResp := pool.sendLong(
-			Msg{"type": "wait", "sessionId": s1, "timeout": 120000},
-			150*time.Second,
+			Msg{"type": "wait", "sessionId": s1, "timeout": 60000},
+			75*time.Second,
 		)
 		assertNotError(t, waitResp)
 		assertContains(t, strVal(waitResp, "content"), "goodbye")
@@ -216,7 +216,7 @@ func TestSession(t *testing.T) {
 		s2 = strVal(startResp, "sessionId")
 
 		// Wait until s2 is actually processing before testing followup rejection
-		pool.awaitStatus(s2, "processing", 30*time.Second)
+		pool.awaitStatus(s2, "processing", 15*time.Second)
 
 		resp := pool.send(Msg{"type": "followup", "sessionId": s2, "prompt": "ignore that"})
 		assertError(t, resp)
@@ -244,8 +244,8 @@ func TestSession(t *testing.T) {
 		}
 
 		waitResp := pool.sendLong(
-			Msg{"type": "wait", "sessionId": s2, "timeout": 120000},
-			150*time.Second,
+			Msg{"type": "wait", "sessionId": s2, "timeout": 60000},
+			75*time.Second,
 		)
 		assertNotError(t, waitResp)
 		assertContains(t, strVal(waitResp, "content"), "interrupted")
@@ -277,7 +277,7 @@ func TestSession(t *testing.T) {
 		s4 := strVal(r2, "sessionId")
 
 		// No sessionId — returns the first owned session that becomes idle
-		resp := pool.sendLong(Msg{"type": "wait", "timeout": 120000}, 150*time.Second)
+		resp := pool.sendLong(Msg{"type": "wait", "timeout": 60000}, 75*time.Second)
 		assertNotError(t, resp)
 
 		sid := strVal(resp, "sessionId")
@@ -292,8 +292,8 @@ func TestSession(t *testing.T) {
 			other = s4
 		}
 		cleanup := pool.sendLong(
-			Msg{"type": "wait", "sessionId": other, "timeout": 120000},
-			150*time.Second,
+			Msg{"type": "wait", "sessionId": other, "timeout": 60000},
+			75*time.Second,
 		)
 		assertNotError(t, cleanup)
 
@@ -314,7 +314,7 @@ func TestSession(t *testing.T) {
 		assertNotError(t, startResp)
 		sid := strVal(startResp, "sessionId")
 
-		pool.awaitStatus(sid, "processing", 30*time.Second)
+		pool.awaitStatus(sid, "processing", 15*time.Second)
 
 		// 1ms timeout — guaranteed to expire before sleep finishes
 		resp := pool.sendLong(Msg{"type": "wait", "sessionId": sid, "timeout": 1}, 5*time.Second)
@@ -350,7 +350,7 @@ func TestSession(t *testing.T) {
 
 		// Restore s1 via followup so the next step can use it
 		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "respond with exactly the text: restored"})
-		pool.sendLong(Msg{"type": "wait", "sessionId": s1, "timeout": 120000}, 150*time.Second)
+		pool.sendLong(Msg{"type": "wait", "sessionId": s1, "timeout": 60000}, 75*time.Second)
 	})
 
 	t.Run("session prefix resolution", func(t *testing.T) {

--- a/tests/integration/slots_test.go
+++ b/tests/integration/slots_test.go
@@ -44,8 +44,8 @@ func TestSlots(t *testing.T) {
 		assertNotError(t, r2)
 		s2 = strVal(r2, "sessionId")
 
-		pool.awaitStatus(s1, "idle", 120*time.Second)
-		pool.awaitStatus(s2, "idle", 120*time.Second)
+		pool.awaitStatus(s1, "idle", 60*time.Second)
+		pool.awaitStatus(s2, "idle", 60*time.Second)
 
 		healthResp := pool.send(Msg{"type": "health"})
 		health, _ := healthResp["health"].(map[string]any)
@@ -116,7 +116,7 @@ func TestSlots(t *testing.T) {
 		pool.awaitStatus(s1, "offloaded", 10*time.Second)
 
 		// s4 should dequeue into the freed slot
-		pool.awaitStatus(s4, "idle", 120*time.Second)
+		pool.awaitStatus(s4, "idle", 60*time.Second)
 
 		// After spawning, claudeUUID and PID should be populated
 		info := pool.send(Msg{"type": "info", "sessionId": s4})
@@ -147,7 +147,7 @@ func TestSlots(t *testing.T) {
 		s5 := strVal(r, "sessionId")
 
 		// s4 (priority -1) should be evicted, not s2 (priority 10)
-		pool.awaitStatus(s4, "offloaded", 30*time.Second)
+		pool.awaitStatus(s4, "offloaded", 15*time.Second)
 
 		info2 := pool.send(Msg{"type": "info", "sessionId": s2})
 		session2 := parseSession(t, info2["session"])
@@ -155,7 +155,7 @@ func TestSlots(t *testing.T) {
 			t.Fatalf("expected s2 to survive eviction, got status %q", session2.Status)
 		}
 
-		pool.awaitStatus(s5, "idle", 120*time.Second)
+		pool.awaitStatus(s5, "idle", 60*time.Second)
 
 		// Reset priorities and clean up for next steps
 		pool.send(Msg{"type": "set-priority", "sessionId": s2, "priority": 0})
@@ -186,14 +186,14 @@ func TestSlots(t *testing.T) {
 
 		// Touch slotB by sending a followup — makes it most recently used
 		pool.send(Msg{"type": "followup", "sessionId": slotB, "prompt": "respond with exactly: recent"})
-		pool.awaitStatus(slotB, "idle", 120*time.Second)
+		pool.awaitStatus(slotB, "idle", 60*time.Second)
 
 		// Start new session — slotA (older/less recent) should be evicted
 		r := pool.send(Msg{"type": "start", "prompt": "respond with exactly: lru"})
 		assertNotError(t, r)
 		newSid := strVal(r, "sessionId")
 
-		pool.awaitStatus(slotA, "offloaded", 30*time.Second)
+		pool.awaitStatus(slotA, "offloaded", 15*time.Second)
 
 		infoB := pool.send(Msg{"type": "info", "sessionId": slotB})
 		sessionB := parseSession(t, infoB["session"])
@@ -201,7 +201,7 @@ func TestSlots(t *testing.T) {
 			t.Fatalf("expected recently-used session to survive, got status %q", sessionB.Status)
 		}
 
-		pool.awaitStatus(newSid, "idle", 120*time.Second)
+		pool.awaitStatus(newSid, "idle", 60*time.Second)
 
 		// Archive old sessions to manage capacity
 		pool.send(Msg{"type": "archive", "sessionId": slotA})
@@ -230,7 +230,7 @@ func TestSlots(t *testing.T) {
 		assertNotError(t, r)
 		newSid := strVal(r, "sessionId")
 
-		pool.awaitStatus(unpinTarget, "offloaded", 30*time.Second)
+		pool.awaitStatus(unpinTarget, "offloaded", 15*time.Second)
 
 		infoP := pool.send(Msg{"type": "info", "sessionId": pinTarget})
 		sessionP := parseSession(t, infoP["session"])
@@ -241,7 +241,7 @@ func TestSlots(t *testing.T) {
 			t.Fatal("expected pinned=true")
 		}
 
-		pool.awaitStatus(newSid, "idle", 120*time.Second)
+		pool.awaitStatus(newSid, "idle", 60*time.Second)
 		pool.send(Msg{"type": "unpin", "sessionId": pinTarget})
 		pool.send(Msg{"type": "archive", "sessionId": unpinTarget})
 	})
@@ -257,7 +257,7 @@ func TestSlots(t *testing.T) {
 			t.Fatalf("expected queued/processing/idle after pin, got %q", status)
 		}
 
-		pool.awaitStatus(s4, "idle", 120*time.Second)
+		pool.awaitStatus(s4, "idle", 60*time.Second)
 
 		info := pool.send(Msg{"type": "info", "sessionId": s4})
 		session := parseSession(t, info["session"])
@@ -283,7 +283,7 @@ func TestSlots(t *testing.T) {
 		pinSid := strVal(resp, "sessionId")
 		assertNonEmpty(t, "pin sessionId", pinSid)
 
-		pool.awaitStatus(pinSid, "idle", 120*time.Second)
+		pool.awaitStatus(pinSid, "idle", 60*time.Second)
 
 		info := pool.send(Msg{"type": "info", "sessionId": pinSid})
 		session := parseSession(t, info["session"])
@@ -337,7 +337,7 @@ func TestSlots(t *testing.T) {
 			pool.send(Msg{"type": "followup", "sessionId": sid, "prompt": "run the bash command: sleep 60"})
 		}
 		for _, sid := range idle {
-			pool.awaitStatus(sid, "processing", 30*time.Second)
+			pool.awaitStatus(sid, "processing", 15*time.Second)
 		}
 
 		// Queue a new session
@@ -376,7 +376,7 @@ func TestSlots(t *testing.T) {
 			pool.send(Msg{"type": "followup", "sessionId": sid, "prompt": "run the bash command: sleep 60"})
 		}
 		for _, sid := range idle {
-			pool.awaitStatus(sid, "processing", 30*time.Second)
+			pool.awaitStatus(sid, "processing", 15*time.Second)
 		}
 
 		// Queue a new session
@@ -398,8 +398,8 @@ func TestSlots(t *testing.T) {
 
 		// Wait for the queued session to finish
 		waitResp := pool.sendLong(
-			Msg{"type": "wait", "sessionId": queuedSid, "timeout": 120000},
-			150*time.Second,
+			Msg{"type": "wait", "sessionId": queuedSid, "timeout": 60000},
+			75*time.Second,
 		)
 		assertNotError(t, waitResp)
 		assertContains(t, strVal(waitResp, "content"), "replaced")

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -44,7 +44,7 @@ func TestSubscribe(t *testing.T) {
 		// Collect events until we see idle
 		var sawCreated, sawIdle bool
 		for i := 0; i < 20; i++ {
-			ev, ok := sub.nextWithin(15 * time.Second)
+			ev, ok := sub.nextWithin(10 * time.Second)
 			if !ok {
 				break
 			}
@@ -88,7 +88,7 @@ func TestSubscribe(t *testing.T) {
 			}
 		}
 
-		pool.awaitStatus(s2, "idle", 120*time.Second)
+		pool.awaitStatus(s2, "idle", 60*time.Second)
 	})
 
 	t.Run("subscribe receives pool events", func(t *testing.T) {
@@ -139,8 +139,8 @@ func TestSubscribe(t *testing.T) {
 			t.Fatal("should not receive events for s2 with session filter")
 		}
 
-		pool.awaitStatus(s1, "idle", 120*time.Second)
-		pool.awaitStatus(s2, "idle", 120*time.Second)
+		pool.awaitStatus(s1, "idle", 60*time.Second)
+		pool.awaitStatus(s2, "idle", 60*time.Second)
 	})
 
 	t.Run("filter by events", func(t *testing.T) {
@@ -181,7 +181,7 @@ func TestSubscribe(t *testing.T) {
 
 		// Restore s2 for later steps
 		pool.send(Msg{"type": "followup", "sessionId": s2, "prompt": "respond with exactly: back"})
-		pool.awaitStatus(s2, "idle", 120*time.Second)
+		pool.awaitStatus(s2, "idle", 60*time.Second)
 
 		// Archive s3 to stay within capacity
 		pool.send(Msg{"type": "archive", "sessionId": s3})
@@ -195,7 +195,7 @@ func TestSubscribe(t *testing.T) {
 		// Should only see transitions TO idle, not to processing
 		var sawIdle, sawProcessing bool
 		for i := 0; i < 10; i++ {
-			ev, ok := sub.nextWithin(15 * time.Second)
+			ev, ok := sub.nextWithin(10 * time.Second)
 			if !ok {
 				break
 			}
@@ -224,7 +224,7 @@ func TestSubscribe(t *testing.T) {
 		// Only s1→idle should arrive
 		var matched bool
 		for i := 0; i < 10; i++ {
-			ev, ok := sub.nextWithin(15 * time.Second)
+			ev, ok := sub.nextWithin(10 * time.Second)
 			if !ok {
 				break
 			}
@@ -243,8 +243,8 @@ func TestSubscribe(t *testing.T) {
 			t.Fatal("expected s1 idle event")
 		}
 
-		pool.awaitStatus(s1, "idle", 120*time.Second)
-		pool.awaitStatus(s2, "idle", 120*time.Second)
+		pool.awaitStatus(s1, "idle", 60*time.Second)
+		pool.awaitStatus(s2, "idle", 60*time.Second)
 	})
 
 	t.Run("re-subscribe replaces filters", func(t *testing.T) {
@@ -277,8 +277,8 @@ func TestSubscribe(t *testing.T) {
 			t.Fatal("expected s2 events after re-subscribe")
 		}
 
-		pool.awaitStatus(s1, "idle", 120*time.Second)
-		pool.awaitStatus(s2, "idle", 120*time.Second)
+		pool.awaitStatus(s1, "idle", 60*time.Second)
+		pool.awaitStatus(s2, "idle", 60*time.Second)
 	})
 
 	t.Run("updated event — priority change", func(t *testing.T) {
@@ -336,8 +336,8 @@ func TestSubscribe(t *testing.T) {
 
 		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "run these bash commands: mkdir -p cwd_sub_test && cd cwd_sub_test"})
 		pool.sendLong(
-			Msg{"type": "wait", "sessionId": s1, "timeout": 120000},
-			150*time.Second,
+			Msg{"type": "wait", "sessionId": s1, "timeout": 60000},
+			75*time.Second,
 		)
 
 		ev, ok := sub.nextWithin(10 * time.Second)
@@ -405,7 +405,7 @@ func TestSubscribe(t *testing.T) {
 
 		// Restore s1 for the next test
 		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "respond with exactly: back"})
-		pool.awaitStatus(s1, "idle", 120*time.Second)
+		pool.awaitStatus(s1, "idle", 60*time.Second)
 	})
 
 	t.Run("multiple concurrent subscribers", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Halves most test timeouts to surface stuck sessions faster
- Protocol I/O: 30s → 10s, await idle: 120s → 60s, await processing: 30s → 15s, wait command: 120s → 60s
- Haiku one-liners finish in 10-20s — previous 2-minute timeouts were far too generous

## Test plan

- [ ] Run full integration suite: `go test ./tests/integration/ -v -timeout 10m`
- [ ] Run CLI tests: `go test ./tests/cli/ -v -timeout 10m`
- [ ] Verify no flaky timeouts under normal conditions