### PR TITLE
Add attach pipe integration tests (TDD)

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -250,7 +250,7 @@ Priority defaults to 0 for new sessions. Use `set-priority` to change it after c
 **Behavior:** Manually offload a session to free its slot. Saves session metadata, frees the slot's resources, and transitions the session to `offloaded`. The JSONL transcript (maintained by Claude Code itself) serves as the persistent record and is always accessible via the session's Claude UUID.
 
 - Only works for **idle** sessions. Errors if **processing**, **typing**, **queued** (nothing to offload), or already **offloaded**.
-- If session is **pinned** → errors (unpin first).
+- If session is **pinned** → automatically unpinned before offloading.
 
 ---
 

--- a/tests/integration/CLAUDE.md
+++ b/tests/integration/CLAUDE.md
@@ -45,6 +45,7 @@ Each test file = one pool, one flow, multiple subtests:
 | `offload_test.go` | 2 | Offload, capture while offloaded, restore, archive lifecycle |
 | `parent_child_test.go` | 3 | Ownership, ls/tree, info, recursive archive |
 | `subscribe_test.go` | 2 | Event stream, filters, re-subscribe, updated events |
+| `attach_test.go` | 2 | Attach pipe, typing detection, followup while attached, offload closes pipe, re-attach |
 
 Shared infrastructure:
 

--- a/tests/integration/attach_test.go
+++ b/tests/integration/attach_test.go
@@ -22,6 +22,7 @@ package integration
 //   9.  "re-pin and re-attach after offload"
 
 import (
+	"errors"
 	"io"
 	"net"
 	"testing"
@@ -130,8 +131,8 @@ func TestAttach(t *testing.T) {
 		buf := make([]byte, 1)
 		attachConn.SetReadDeadline(time.Now().Add(5 * time.Second))
 		_, err := attachConn.Read(buf)
-		if err != io.EOF {
-			t.Fatalf("expected EOF after offload, got: %v", err)
+		if !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
+			t.Fatalf("expected EOF or closed after offload, got: %v", err)
 		}
 	})
 
@@ -173,7 +174,7 @@ func TestAttach(t *testing.T) {
 			t.Fatal("expected output from re-attached session")
 		}
 
-		// Clean up typed character
+		// Best-effort cleanup
 		newConn.Write([]byte("\x15"))
 	})
 }
@@ -188,4 +189,5 @@ func drainAttach(conn net.Conn) {
 			break
 		}
 	}
+	conn.SetReadDeadline(time.Time{})
 }


### PR DESCRIPTION
## Summary

- New integration test flow `attach_test.go` (pool size 2, 9 steps) covering the full attach lifecycle: pin → attach → typing detection → clear input → submit via PTY → API followup while attached → offload closes pipe → attach-on-offloaded errors → re-pin + re-attach
- Protocol clarification: `offload` now auto-unpins pinned sessions (consistent with how `archive` already works)
- Tests compile (`go vet` passes) but will fail at runtime until `attach` command handling and typing detection are implemented — this is intentional TDD

## Test plan

- [x] `go vet ./tests/integration/` passes
- [ ] Tests will pass once attach + typing detection are implemented