### PR TITLE
Fix test cleanup race that leaks child processes

### DIFF
--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -191,7 +191,7 @@ func setupDaemon(t *testing.T, size int) *testPool {
 	p.startDaemon()
 
 	t.Cleanup(func() {
-		p.sendRaw(Msg{"type": "destroy", "confirm": true})
+		p.send(Msg{"type": "destroy", "confirm": true})
 		p.conn.Close()
 		if p.daemon != nil && p.daemon.Process != nil {
 			p.daemon.Process.Kill()


### PR DESCRIPTION
## Summary

- Test cleanup used `sendRaw` (fire-and-forget) for `destroy`, then immediately `daemon.Process.Kill()` — the daemon could be killed before processing the destroy message, leaving orphaned Claude child processes
- Changed to `send` (waits for response) so the daemon finishes killing all child sessions before it's torn down

## Test plan

- [ ] Run integration tests, verify no orphaned `claude` processes after test completion