### PR TITLE
Preserve test artifacts on failure for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .wt/
+.run/
 *.sock

--- a/tests/cli/helpers_test.go
+++ b/tests/cli/helpers_test.go
@@ -27,20 +27,16 @@ import (
 var (
 	daemonBinPath string
 	cliBinPath    string
+	runDir        string
 )
 
 func TestMain(m *testing.M) {
-	tmpDir, err := os.MkdirTemp("", "claude-pool-cli-test-*")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
-		os.Exit(1)
-	}
-
 	repoRoot := testutil.FindRepoRoot()
+	runDir = testutil.SetupRunDir(repoRoot, "cli")
 
 	// Build daemon and CLI in parallel — they're independent
-	daemonBinPath = filepath.Join(tmpDir, "claude-pool")
-	cliBinPath = filepath.Join(tmpDir, "claude-pool-cli")
+	daemonBinPath = filepath.Join(runDir, "claude-pool")
+	cliBinPath = filepath.Join(runDir, "claude-pool-cli")
 
 	type buildResult struct {
 		name string
@@ -65,14 +61,17 @@ func TestMain(m *testing.M) {
 	for i := 0; i < 2; i++ {
 		r := <-ch
 		if r.err != nil {
-			os.RemoveAll(tmpDir)
 			fmt.Fprintf(os.Stderr, "failed to build %s: %v\n%s\n", r.name, r.err, r.out)
 			os.Exit(1)
 		}
 	}
 
 	code := m.Run()
-	os.RemoveAll(tmpDir)
+	if code == 0 {
+		os.RemoveAll(runDir)
+	} else {
+		fmt.Fprintf(os.Stderr, "\n=== Test artifacts preserved at: %s ===\n", runDir)
+	}
 	os.Exit(code)
 }
 
@@ -98,7 +97,10 @@ type cmdResult struct {
 func setupCLIPool(t *testing.T, size int) *cliPool {
 	t.Helper()
 
-	poolDir := t.TempDir()
+	poolDir := filepath.Join(runDir, t.Name())
+	if err := os.MkdirAll(poolDir, 0755); err != nil {
+		t.Fatalf("failed to create pool dir: %v", err)
+	}
 	socketPath := filepath.Join(poolDir, "api.sock")
 	poolName := "test"
 
@@ -114,7 +116,10 @@ func setupCLIPool(t *testing.T, size int) *cliPool {
 	}
 
 	// Write registry so CLI can resolve pool name → socket
-	registryDir := t.TempDir()
+	registryDir := filepath.Join(poolDir, "registry")
+	if err := os.MkdirAll(registryDir, 0755); err != nil {
+		t.Fatalf("failed to create registry dir: %v", err)
+	}
 	registry := Msg{
 		poolName: Msg{"socket": socketPath},
 	}

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -30,21 +30,25 @@ import (
 )
 
 // daemonBinPath is built once by TestMain and shared across all test functions.
-var daemonBinPath string
+// runDir holds pool directories for the current run — preserved on failure.
+var (
+	daemonBinPath string
+	runDir        string
+)
 
 func TestMain(m *testing.M) {
-	tmpDir, err := os.MkdirTemp("", "claude-pool-test-*")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
-		os.Exit(1)
-	}
-
 	repoRoot := testutil.FindRepoRoot()
-	daemonBinPath = filepath.Join(tmpDir, "claude-pool")
+	runDir = testutil.SetupRunDir(repoRoot, "integ")
+
+	daemonBinPath = filepath.Join(runDir, "claude-pool")
 	testutil.BuildBinary(repoRoot, daemonBinPath, "./cmd/claude-pool")
 
 	code := m.Run()
-	os.RemoveAll(tmpDir)
+	if code == 0 {
+		os.RemoveAll(runDir)
+	} else {
+		fmt.Fprintf(os.Stderr, "\n=== Test artifacts preserved at: %s ===\n", runDir)
+	}
 	os.Exit(code)
 }
 
@@ -168,7 +172,10 @@ func setupPool(t *testing.T, size int) *testPool {
 func setupDaemon(t *testing.T, size int) *testPool {
 	t.Helper()
 
-	poolDir := t.TempDir()
+	poolDir := filepath.Join(runDir, t.Name())
+	if err := os.MkdirAll(poolDir, 0755); err != nil {
+		t.Fatalf("failed to create pool dir: %v", err)
+	}
 	socketPath := filepath.Join(poolDir, "api.sock")
 
 	configPath := filepath.Join(poolDir, "config.json")

--- a/tests/testutil/testutil.go
+++ b/tests/testutil/testutil.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
 )
 
 // FindRepoRoot walks up from cwd to find the directory containing go.mod.
@@ -37,5 +39,58 @@ func BuildBinary(repoRoot, outputPath, pkg string) {
 	if out, err := build.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to build %s: %v\n%s\n", pkg, err, out)
 		os.Exit(1)
+	}
+}
+
+// SetupRunDir creates a timestamped run directory for test artifacts at
+// <repoRoot>/.run/<prefix>-<timestamp>/. Prunes old runs (>1 hour).
+// On success the caller removes the run dir; on failure it stays for inspection.
+//
+// Keep paths short — Unix sockets have a 104-byte limit on macOS. The full
+// path to api.sock must fit: <repoRoot>/.run/<prefix>-<ts>/<TestName>/api.sock
+func SetupRunDir(repoRoot, prefix string) string {
+	baseDir := filepath.Join(repoRoot, ".run")
+	pruneOldRuns(baseDir, time.Hour)
+
+	stamp := time.Now().Format(stampFormat)
+	dir := filepath.Join(baseDir, fmt.Sprintf("%s-%s", prefix, stamp))
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create run dir: %v\n", err)
+		os.Exit(1)
+	}
+	return dir
+}
+
+const stampFormat = "0102-150405"
+
+// pruneOldRuns removes subdirectories of baseDir whose embedded timestamp
+// is older than maxAge. Parses the timestamp from the directory name
+// (format: <prefix>-MMDD-HHMMSS) rather than relying on mtime, which can
+// be updated by writes to files inside the directory.
+func pruneOldRuns(baseDir string, maxAge time.Duration) {
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-maxAge)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		// Extract timestamp after the last "-" prefix separator
+		// Dir name format: <prefix>-MMDD-HHMMSS
+		name := e.Name()
+		if idx := strings.Index(name, "-"); idx >= 0 {
+			stamp := name[idx+1:]
+			t, err := time.Parse(stampFormat, stamp)
+			if err != nil {
+				continue
+			}
+			// Parse gives year 0 — set to current year for comparison
+			t = t.AddDate(time.Now().Year(), 0, 0)
+			if t.Before(cutoff) {
+				os.RemoveAll(filepath.Join(baseDir, name))
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Replace `t.TempDir()` with managed `.run/` directories at the repo root (gitignored)
- On test failure: artifacts preserved + path printed to stderr
- On success: cleaned up automatically
- Auto-prunes old run dirs (>1 hour) by parsing embedded timestamps
- Short paths stay within macOS 104-byte Unix socket limit

## Test plan

- [x] Integration tests run, daemon starts, socket binds
- [x] Artifacts preserved on failure with clear message
- [x] `go vet ./tests/...` passes