### PR TITLE
Deduplicate test helpers: shared utilities in testutil

### DIFF
--- a/tests/cli/helpers_test.go
+++ b/tests/cli/helpers_test.go
@@ -200,11 +200,24 @@ func setupCLIPool(t *testing.T, size int) *cliPool {
 // run executes a CLI command and returns stdout, stderr, and exit code.
 func (p *cliPool) run(args ...string) cmdResult {
 	p.t.Helper()
+	return p.execCLI(nil, args...)
+}
+
+// runInSession executes a CLI command with CLAUDE_POOL_SESSION_ID set,
+// simulating a call from within a pool session.
+func (p *cliPool) runInSession(sessionID string, args ...string) cmdResult {
+	p.t.Helper()
+	return p.execCLI([]string{
+		fmt.Sprintf("CLAUDE_POOL_SESSION_ID=%s", sessionID),
+	}, args...)
+}
+
+// execCLI runs the CLI binary with --pool prepended and optional extra env vars.
+func (p *cliPool) execCLI(extraEnv []string, args ...string) cmdResult {
+	p.t.Helper()
 	fullArgs := append([]string{"--pool", p.poolName}, args...)
 	cmd := exec.Command(p.cliBin, fullArgs...)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("CLAUDE_POOL_REGISTRY=%s", os.Getenv("CLAUDE_POOL_REGISTRY")),
-	)
+	cmd.Env = append(os.Environ(), extraEnv...)
 
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
@@ -241,38 +254,6 @@ func (p *cliPool) runJSON(args ...string) Msg {
 	return msg
 }
 
-// runInSession executes a CLI command with CLAUDE_POOL_SESSION_ID set,
-// simulating a call from within a pool session.
-func (p *cliPool) runInSession(sessionID string, args ...string) cmdResult {
-	p.t.Helper()
-	fullArgs := append([]string{"--pool", p.poolName}, args...)
-	cmd := exec.Command(p.cliBin, fullArgs...)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("CLAUDE_POOL_REGISTRY=%s", os.Getenv("CLAUDE_POOL_REGISTRY")),
-		fmt.Sprintf("CLAUDE_POOL_SESSION_ID=%s", sessionID),
-	)
-
-	var stdout, stderr strings.Builder
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	exitCode := 0
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			p.t.Fatalf("failed to run CLI: %v", err)
-		}
-	}
-
-	return cmdResult{
-		Stdout:   stdout.String(),
-		Stderr:   stderr.String(),
-		ExitCode: exitCode,
-	}
-}
-
 // runInSessionJSON is runInSession + JSON parsing.
 func (p *cliPool) runInSessionJSON(sessionID string, args ...string) Msg {
 	p.t.Helper()
@@ -287,9 +268,4 @@ func (p *cliPool) runInSessionJSON(sessionID string, args ...string) Msg {
 	return msg
 }
 
-func strVal(m map[string]any, key string) string {
-	if v, ok := m[key].(string); ok {
-		return v
-	}
-	return ""
-}
+var strVal = testutil.StrVal

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -115,26 +115,11 @@ func parseSessions(t *testing.T, resp Msg) []SessionInfo {
 	return sessions
 }
 
-func strVal(m map[string]any, key string) string {
-	if v, ok := m[key].(string); ok {
-		return v
-	}
-	return ""
-}
-
-func numVal(m map[string]any, key string) float64 {
-	if v, ok := m[key].(float64); ok {
-		return v
-	}
-	return 0
-}
-
-func boolVal(m map[string]any, key string) bool {
-	if v, ok := m[key].(bool); ok {
-		return v
-	}
-	return false
-}
+var (
+	strVal  = testutil.StrVal
+	numVal  = testutil.NumVal
+	boolVal = testutil.BoolVal
+)
 
 // --------------------------------------------------------------------
 // Test pool

--- a/tests/testutil/testutil.go
+++ b/tests/testutil/testutil.go
@@ -63,6 +63,30 @@ func SetupRunDir(repoRoot, prefix string) string {
 
 const stampFormat = "0102-150405"
 
+// StrVal extracts a string from a JSON map, returning "" if missing or wrong type.
+func StrVal(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// NumVal extracts a float64 from a JSON map, returning 0 if missing or wrong type.
+func NumVal(m map[string]any, key string) float64 {
+	if v, ok := m[key].(float64); ok {
+		return v
+	}
+	return 0
+}
+
+// BoolVal extracts a bool from a JSON map, returning false if missing or wrong type.
+func BoolVal(m map[string]any, key string) bool {
+	if v, ok := m[key].(bool); ok {
+		return v
+	}
+	return false
+}
+
 // pruneOldRuns removes subdirectories of baseDir whose embedded timestamp
 // is older than maxAge. Parses the timestamp from the directory name
 // (format: <prefix>-MMDD-HHMMSS) rather than relying on mtime, which can


### PR DESCRIPTION
## Summary

- Move `strVal`/`numVal`/`boolVal` to `testutil` package — eliminates duplicate definitions across integration and CLI test packages
- Extract `execCLI` from `run`/`runInSession` — removes ~30 lines of duplicated exec/capture logic
- Remove redundant `CLAUDE_POOL_REGISTRY` env var re-append — `os.Environ()` already includes it via `t.Setenv`

Net -15 lines.

## Test plan

- [x] `go vet ./tests/...` passes
- [x] All call sites use the same function signatures (no behavioral change)