### PR TITLE
Fix test races and timing in integration tests

### DIFF
--- a/tests/integration/attach_test.go
+++ b/tests/integration/attach_test.go
@@ -34,6 +34,11 @@ func TestAttach(t *testing.T) {
 
 	var s1 string
 	var attachConn net.Conn
+	t.Cleanup(func() {
+		if attachConn != nil {
+			attachConn.Close()
+		}
+	})
 
 	t.Run("pin fresh session", func(t *testing.T) {
 		resp := pool.send(Msg{"type": "pin"})
@@ -59,8 +64,6 @@ func TestAttach(t *testing.T) {
 		if err != nil {
 			t.Fatalf("connect to attach socket: %v", err)
 		}
-		t.Cleanup(func() { attachConn.Close() })
-
 		drainAttach(attachConn)
 	})
 

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -333,10 +333,21 @@ func (p *testPool) awaitSocketGone(timeout time.Duration) {
 // awaitStatus subscribes to status events for a specific session and waits
 // until it reaches the target status. Uses subscribe rather than polling —
 // same as a production client would.
+//
+// Subscribes BEFORE checking current state to avoid the TOCTOU race where
+// a transition fires between the check and the subscribe registration.
 func (p *testPool) awaitStatus(sessionID, target string, timeout time.Duration) SessionInfo {
 	p.t.Helper()
 
-	// Check immediately — might already be at target
+	// Subscribe first — ensures no events are missed between check and listen
+	sub := p.subscribe(Msg{
+		"sessions": []string{sessionID},
+		"events":   []string{"status"},
+		"statuses": []string{target},
+	})
+	defer sub.close()
+
+	// Now check — if already at target, done
 	resp := p.send(Msg{"type": "info", "sessionId": sessionID})
 	if resp["type"] == "error" {
 		p.t.Fatalf("awaitStatus info failed: %v", resp["error"])
@@ -345,14 +356,6 @@ func (p *testPool) awaitStatus(sessionID, target string, timeout time.Duration) 
 	if info.Status == target {
 		return info
 	}
-
-	// Subscribe to status events for this specific session
-	sub := p.subscribe(Msg{
-		"sessions": []string{sessionID},
-		"events":   []string{"status"},
-		"statuses": []string{target},
-	})
-	defer sub.close()
 
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -381,19 +384,19 @@ func (p *testPool) awaitStatus(sessionID, target string, timeout time.Duration) 
 // awaitPoolSize subscribes to pool events and waits until the pool reaches
 // the target slot count. Uses subscribe rather than polling — same as a
 // production client would.
+//
+// Subscribes BEFORE checking current state to avoid the TOCTOU race.
 func (p *testPool) awaitPoolSize(target int, timeout time.Duration) {
 	p.t.Helper()
 
-	// Check immediately — might already be at target
+	sub := p.subscribe(Msg{"events": []string{"pool"}})
+	defer sub.close()
+
 	resp := p.send(Msg{"type": "health"})
 	health, _ := resp["health"].(map[string]any)
 	if int(numVal(health, "size")) == target {
 		return
 	}
-
-	// Subscribe to pool events (resize, init, etc.) on a dedicated connection
-	sub := p.subscribe(Msg{"events": []string{"pool"}})
-	defer sub.close()
 
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -412,8 +415,13 @@ func (p *testPool) awaitPoolSize(target int, timeout time.Duration) {
 
 // awaitIdleCount subscribes to status events and waits until at least n
 // sessions are idle. Uses subscribe rather than polling.
+//
+// Subscribes BEFORE checking current state to avoid the TOCTOU race.
 func (p *testPool) awaitIdleCount(n int, timeout time.Duration) {
 	p.t.Helper()
+
+	sub := p.subscribe(Msg{"events": []string{"status"}, "statuses": []string{"idle"}})
+	defer sub.close()
 
 	resp := p.send(Msg{"type": "health"})
 	health, _ := resp["health"].(map[string]any)
@@ -421,10 +429,6 @@ func (p *testPool) awaitIdleCount(n int, timeout time.Duration) {
 	if int(numVal(counts, "idle")) >= n {
 		return
 	}
-
-	// Subscribe to idle transitions — each event means a session just became idle
-	sub := p.subscribe(Msg{"events": []string{"status"}, "statuses": []string{"idle"}})
-	defer sub.close()
 
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -41,10 +41,10 @@ func TestSubscribe(t *testing.T) {
 		assertNotError(t, resp)
 		s1 = strVal(resp, "sessionId")
 
-		// Collect events until we see idle
+		// Collect events until we see idle (30s per event — model may be slow to start)
 		var sawCreated, sawIdle bool
 		for i := 0; i < 20; i++ {
-			ev, ok := sub.nextWithin(10 * time.Second)
+			ev, ok := sub.nextWithin(30 * time.Second)
 			if !ok {
 				break
 			}
@@ -121,7 +121,7 @@ func TestSubscribe(t *testing.T) {
 		// Collect events — only s1 events should appear
 		var sawS1, sawS2 bool
 		for i := 0; i < 20; i++ {
-			ev, ok := sub.nextWithin(5 * time.Second)
+			ev, ok := sub.nextWithin(10 * time.Second)
 			if !ok {
 				break
 			}
@@ -157,7 +157,7 @@ func TestSubscribe(t *testing.T) {
 		// Should receive status events but NOT created events
 		var sawStatus, sawCreated bool
 		for i := 0; i < 20; i++ {
-			ev, ok := sub.nextWithin(10 * time.Second)
+			ev, ok := sub.nextWithin(30 * time.Second)
 			if !ok {
 				break
 			}
@@ -195,7 +195,7 @@ func TestSubscribe(t *testing.T) {
 		// Should only see transitions TO idle, not to processing
 		var sawIdle, sawProcessing bool
 		for i := 0; i < 10; i++ {
-			ev, ok := sub.nextWithin(10 * time.Second)
+			ev, ok := sub.nextWithin(30 * time.Second)
 			if !ok {
 				break
 			}
@@ -224,7 +224,7 @@ func TestSubscribe(t *testing.T) {
 		// Only s1→idle should arrive
 		var matched bool
 		for i := 0; i < 10; i++ {
-			ev, ok := sub.nextWithin(10 * time.Second)
+			ev, ok := sub.nextWithin(30 * time.Second)
 			if !ok {
 				break
 			}
@@ -259,7 +259,7 @@ func TestSubscribe(t *testing.T) {
 		// Should only see s2 events (filters were replaced)
 		var sawS1, sawS2 bool
 		for i := 0; i < 20; i++ {
-			ev, ok := sub.nextWithin(5 * time.Second)
+			ev, ok := sub.nextWithin(10 * time.Second)
 			if !ok {
 				break
 			}
@@ -418,7 +418,7 @@ func TestSubscribe(t *testing.T) {
 		// sub1 should only see s1, sub2 should only see s2
 		var sub1SawS1, sub1SawS2 bool
 		for i := 0; i < 10; i++ {
-			ev, ok := sub1.nextWithin(5 * time.Second)
+			ev, ok := sub1.nextWithin(10 * time.Second)
 			if !ok {
 				break
 			}
@@ -433,7 +433,7 @@ func TestSubscribe(t *testing.T) {
 
 		var sub2SawS1, sub2SawS2 bool
 		for i := 0; i < 10; i++ {
-			ev, ok := sub2.nextWithin(5 * time.Second)
+			ev, ok := sub2.nextWithin(10 * time.Second)
 			if !ok {
 				break
 			}


### PR DESCRIPTION
## Summary

- **TOCTOU race in await helpers**: `awaitStatus`, `awaitPoolSize`, and `awaitIdleCount` had a check-then-subscribe pattern where a state transition between the info check and subscribe registration caused the event to be missed, leading to spurious timeouts ("last status was idle"). Fixed by subscribing BEFORE checking current state.
- **`t.Cleanup` scoping bug in attach_test.go**: `t.Cleanup(attachConn.Close)` was registered on the subtest's `t` (shadowed by `func(t *testing.T)`), so `attachConn` was closed when "attach to idle session" ended — before subsequent subtests used it. Moved cleanup to parent test scope.
- **Subscribe test per-event timeouts too tight**: Bumped from 10s→30s where tests wait for model responses (haiku can be slow under API load), and 5s→10s for multi-event collection loops.

## Test plan

- [ ] Run `go test ./tests/integration/ -v -run TestAttach -timeout 5m` — subtests after "attach to idle session" should now pass
- [ ] Run `go test ./tests/integration/ -v -run TestSlots -timeout 5m` — no more spurious "last status was idle" timeouts
- [ ] Run `go test ./tests/integration/ -v -run TestSubscribe -timeout 10m` — no more inter-event timeouts on slow haiku responses