### PR TITLE
Fix queued-UUID falsehood, add lifecycle docs, fill test gaps

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -68,7 +68,7 @@ Commands that return session output (`wait`, `capture`) accept a `format` field:
 | `buffer-last` | Terminal buffer since last user message. | Yes |
 | `buffer-full` | Full terminal scrollback, ANSI stripped. | Yes |
 
-JSONL formats read from Claude Code's transcript files (via Claude UUID). Work for any session with a known UUID — including offloaded and archived. Buffer formats require a live terminal (idle or processing only).
+JSONL formats read from Claude Code's transcript files (via Claude UUID). Work for any session with a known UUID — including offloaded, archived, and re-queued sessions that retain their UUID. Buffer formats require a live terminal (idle or processing only).
 
 Empty content is valid — if a session was stopped before producing output, JSONL formats might return an empty string.
 
@@ -101,7 +101,7 @@ Transport: Unix domain socket, newline-delimited JSON. See [docs/protocol.md](do
 - **`ls`** — List sessions. Default: owned sessions only. `all: true` for everything. `tree: true` for nested descendants. `archived: true` to include archived.
 - **`info`** — Full session details including Claude UUID, cwd, priority, pin status, and recursive children tree.
 - **`wait`** — Long-poll until a session becomes idle. Returns session output. Without a sessionId, waits for any owned busy session.
-- **`capture`** — Return session output immediately, regardless of state. JSONL formats work for any session with a UUID; buffer formats require a live terminal.
+- **`capture`** — Return session output immediately, regardless of state. JSONL formats work for any session with a UUID (including queued sessions re-queued via `followup`/`pin` that retain their UUID); buffer formats require a live terminal (errors on queued and offloaded sessions).
 
 ### Session Control
 
@@ -147,6 +147,10 @@ Slots are the physical resources that host sessions. Consumers never interact wi
 | `loading` | Starting a new session or resuming an offloaded one. |
 | `live` | Hosting an active session (idle or processing). |
 | `error` | Crashed during startup or loading. Recycled automatically (killed, replaced with fresh). |
+
+### Session Lifecycle Mechanics
+
+All Claude sessions are persistent and headful — the pool never spawns throwaway processes. When a slot needs to host a new session, the pool sends `/clear` to reset the existing Claude process's context. When resuming an offloaded session, the pool sends `/resume <uuid>` to restore it into the cleared slot. This reuse model exists because spawning a new Claude CLI process kills bash command output for all other running Claude processes on the same machine.
 
 ### Debug API
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -212,9 +212,9 @@ Priority defaults to 0 for new sessions. Use `set-priority` to change it after c
 **Response:** `{ type: "result", sessionId, content }` — session output.
 
 **Behavior:** Returns the current session output, regardless of session state.
-- **JSONL formats** work for any session with a known Claude UUID: **idle**, **processing**, **offloaded**, **error**, **archived**. Reads from Claude Code's transcript files.
+- **JSONL formats** work for any session with a known Claude UUID: **idle**, **processing**, **queued** (if re-queued from offloaded), **offloaded**, **error**, **archived**. Reads from Claude Code's transcript files.
 - **Buffer formats** only work for live sessions (**idle**, **processing**). Errors for all other states.
-- Errors if session is **queued** (no UUID or terminal yet).
+- **Queued** sessions: JSONL formats work if the session has a UUID (re-queued from offloaded). Buffer formats error (no live terminal). Sessions queued from scratch (never spawned) have no UUID, so all formats error.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,6 +30,13 @@ Test the CLI → daemon path: arg parsing, env var propagation (`CLAUDE_POOL_SES
 
 See [tests/cli/CLAUDE.md](../tests/cli/CLAUDE.md) for philosophy and file listing.
 
+## Claude Code Constraints
+
+**`cd` only works downward.** Claude Code sessions can `cd` into subdirectories of their spawn directory, but cannot `cd` to directories above it (e.g., `/tmp/`, `~/other-project/`). The Bash tool silently resets cwd to the spawn directory when asked to go higher. This means:
+
+- Tests that verify cwd changes must use relative subdirectories, never absolute paths outside the spawn dir.
+- `cwd` tracking (via process inspection) will only ever show paths at or below `spawnCwd`.
+
 ## Running
 
 ```bash

--- a/schema/protocol.json
+++ b/schema/protocol.json
@@ -12,7 +12,7 @@
     "claudeUUID": {
       "type": "string",
       "pattern": "^[a-f0-9-]+$",
-      "description": "Claude Code session UUID (discovered after spawn, null while queued). Use info command to look up."
+      "description": "Claude Code session UUID (null until first spawn; retained when re-queued from offloaded). Use info command to look up."
     },
 
     "sessionStatus": {

--- a/tests/integration/CLAUDE.md
+++ b/tests/integration/CLAUDE.md
@@ -33,6 +33,10 @@ Tradeoff: a failure mid-flow can cascade. We accept this — fixing the first fa
 fixes the cascade, and the alternative (isolated tests) would be 10x slower and
 require duplicating all the state-building logic.
 
+## Claude Code `cd` Constraint
+
+Sessions can only `cd` into **subdirectories** of their spawn directory. `cd` to paths above the spawn dir (e.g., `/tmp/`, `~/other-project/`) silently fails — cwd resets to spawn dir. All cwd-related test prompts must use relative subdirectories.
+
 ## Structure
 
 Each test file = one pool, one flow, multiple subtests:
@@ -41,9 +45,9 @@ Each test file = one pool, one flow, multiple subtests:
 |------|-----------|----------------|
 | `pool_test.go` | 2 | Init, config, resize, health, destroy, re-init with restore |
 | `session_test.go` | 3 | Start, wait, capture, followup, output formats, input |
-| `slots_test.go` | 2 | Queue, priority, pin/eviction, queued-session behavior |
-| `offload_test.go` | 2 | Offload, capture while offloaded, restore, process death → offloaded, archive lifecycle |
-| `error_test.go` | 2 | Repeated load failures → error state, followup force retry, error session visibility in ls/info |
+| `slots_test.go` | 2 | Queue, priority, pin/eviction, capture on queued, queued-session behavior |
+| `offload_test.go` | 2 | Offload, capture while offloaded, restore, process death → offloaded, wait on death, stop on offloaded/archived, archive lifecycle |
+| ~~`error_test.go`~~ | — | *Deferred: no reliable way to trigger repeated load failures in tests. Will add when a real scenario surfaces.* |
 | `parent_child_test.go` | 3 | Ownership, ls/tree, info, recursive archive |
 | `subscribe_test.go` | 2 | Event stream, filters, re-subscribe, updated events |
 | `attach_test.go` | 2 | Attach pipe, pendingInput detection, followup while attached, all API commands work during attach, offload closes pipe, re-attach |

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -594,6 +594,22 @@ func (s *subscription) drain() []Msg {
 }
 
 // --------------------------------------------------------------------
+// Process helpers
+// --------------------------------------------------------------------
+
+// killPID sends SIGKILL to a process. Fatals on error.
+func killPID(t *testing.T, pid int) {
+	t.Helper()
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		t.Fatalf("find process %d: %v", pid, err)
+	}
+	if err := proc.Kill(); err != nil {
+		t.Fatalf("kill process %d: %v", pid, err)
+	}
+}
+
+// --------------------------------------------------------------------
 // Assertion helpers
 // --------------------------------------------------------------------
 

--- a/tests/integration/offload_test.go
+++ b/tests/integration/offload_test.go
@@ -11,21 +11,25 @@ package integration
 //
 //   1.  "start and wait for idle"
 //   2.  "offload idle session"
-//   3.  "offload pinned session auto-unpins"
-//   4.  "offload non-idle errors"
-//   5.  "capture JSONL on offloaded session works"
-//   6.  "capture buffer on offloaded session errors"
-//   7.  "followup restores offloaded session"
-//   8.  "archive idle session"
-//   9.  "archived session hidden from ls"
-//  10.  "capture JSONL on archived session works"
-//  11.  "capture buffer on archived session errors"
-//  12.  "followup on archived errors"
-//  13.  "pin on archived errors"
-//  14.  "unarchive restores to offloaded"
-//  15.  "unarchive on non-archived errors"
-//  16.  "archive stops active session first"
-//  17.  "archive is idempotent"
+//   3.  "stop on offloaded errors"
+//   4.  "offload pinned session auto-unpins"
+//   5.  "offload non-idle errors"
+//   6.  "capture JSONL on offloaded session works"
+//   7.  "capture buffer on offloaded session errors"
+//   8.  "followup restores offloaded session"
+//   9.  "process death transitions to offloaded"
+//  10.  "wait returns error on session death"
+//  11.  "archive idle session"
+//  12.  "stop on archived errors"
+//  13.  "archived session hidden from ls"
+//  14.  "capture JSONL on archived session works"
+//  15.  "capture buffer on archived session errors"
+//  16.  "followup on archived errors"
+//  17.  "pin on archived errors"
+//  18.  "unarchive restores to offloaded"
+//  19.  "unarchive on non-archived errors"
+//  20.  "archive stops active session first"
+//  21.  "archive is idempotent"
 
 import (
 	"testing"
@@ -61,6 +65,12 @@ func TestOffload(t *testing.T) {
 		if session.PID != 0 {
 			t.Fatalf("offloaded session should have no PID, got %v", session.PID)
 		}
+	})
+
+	t.Run("stop on offloaded errors", func(t *testing.T) {
+		// s1 is offloaded — nothing to stop
+		resp := pool.send(Msg{"type": "stop", "sessionId": s1})
+		assertError(t, resp)
 	})
 
 	t.Run("offload pinned session auto-unpins", func(t *testing.T) {
@@ -125,9 +135,50 @@ func TestOffload(t *testing.T) {
 		}
 	})
 
+	t.Run("process death transitions to offloaded", func(t *testing.T) {
+		// s2 is idle with a live PID — kill it directly
+		info := pool.send(Msg{"type": "info", "sessionId": s2})
+		session := parseSession(t, info["session"])
+		pid := int(session.PID)
+		if pid <= 0 {
+			t.Fatalf("expected live PID for s2, got %v", pid)
+		}
+
+		killPID(t, pid)
+
+		s := pool.awaitStatus(s2, "offloaded", 15*time.Second)
+		if s.PID != 0 {
+			t.Fatalf("dead session should have PID 0, got %v", s.PID)
+		}
+	})
+
+	t.Run("wait returns error on session death", func(t *testing.T) {
+		// s1 is idle — start a long-running task, then kill the process mid-wait
+		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "run the bash command: sleep 120"})
+		pool.awaitStatus(s1, "processing", 15*time.Second)
+
+		info := pool.send(Msg{"type": "info", "sessionId": s1})
+		session := parseSession(t, info["session"])
+		pid := int(session.PID)
+
+		// Use a separate connection for the concurrent wait (main conn isn't thread-safe)
+		waitConn, waitScanner := pool.newConn()
+		ch := make(chan Msg, 1)
+		go func() {
+			ch <- pool.sendOn(waitConn, waitScanner,
+				Msg{"type": "wait", "sessionId": s1, "timeout": 30000},
+			)
+		}()
+
+		// Give wait a moment to register on the server before killing
+		time.Sleep(500 * time.Millisecond)
+		killPID(t, pid)
+
+		assertError(t, <-ch)
+	})
+
 	t.Run("archive idle session", func(t *testing.T) {
-		// Offload first so it frees the slot, then archive
-		pool.send(Msg{"type": "offload", "sessionId": s1})
+		// s1 is offloaded after process death — archive directly
 		pool.awaitStatus(s1, "offloaded", 10*time.Second)
 
 		resp := pool.send(Msg{"type": "archive", "sessionId": s1})
@@ -137,6 +188,12 @@ func TestOffload(t *testing.T) {
 		info := pool.send(Msg{"type": "info", "sessionId": s1})
 		session := parseSession(t, info["session"])
 		assertStatus(t, session, "archived")
+	})
+
+	t.Run("stop on archived errors", func(t *testing.T) {
+		// s1 is archived — nothing to stop
+		resp := pool.send(Msg{"type": "stop", "sessionId": s1})
+		assertError(t, resp)
 	})
 
 	t.Run("archived session hidden from ls", func(t *testing.T) {

--- a/tests/integration/slots_test.go
+++ b/tests/integration/slots_test.go
@@ -14,16 +14,17 @@ package integration
 //
 //   1.  "start fills all slots"
 //   2.  "start queues when all slots busy"
-//   3.  "stop cancels queued start"
-//   4.  "queued session gets slot when one frees"
-//   5.  "set-priority affects eviction order"
-//   6.  "LRU within same priority"
-//   7.  "pin prevents eviction"
-//   8.  "pin on offloaded triggers priority load"
-//   9.  "pin without sessionId allocates fresh"
-//  10.  "unpin clears pinned flag"
-//  11.  "followup on queued errors"
-//  12.  "followup with force on queued replaces prompt"
+//   3.  "capture on fresh-queued session errors"
+//   4.  "stop cancels queued start"
+//   5.  "queued session gets slot when one frees"
+//   6.  "set-priority affects eviction order"
+//   7.  "LRU within same priority"
+//   8.  "pin prevents eviction"
+//   9.  "pin on offloaded triggers priority load"
+//  10.  "pin without sessionId allocates fresh"
+//  11.  "unpin clears pinned flag"
+//  12.  "followup on queued errors"
+//  13.  "followup with force on queued replaces prompt"
 
 import (
 	"testing"
@@ -76,6 +77,7 @@ func TestSlots(t *testing.T) {
 		session := parseSession(t, info["session"])
 		assertStatus(t, session, "queued")
 
+		// Fresh-queued sessions (never spawned) have no UUID
 		if session.ClaudeUUID != "" {
 			t.Fatalf("queued session should have no claudeUUID, got %q", session.ClaudeUUID)
 		}
@@ -87,6 +89,14 @@ func TestSlots(t *testing.T) {
 		health, _ := healthResp["health"].(map[string]any)
 		if numVal(health, "queueDepth") != 1 {
 			t.Fatalf("expected queue depth 1, got %v", numVal(health, "queueDepth"))
+		}
+	})
+
+	t.Run("capture on fresh-queued session errors", func(t *testing.T) {
+		// s3 is queued from scratch — no UUID, no terminal. All capture formats should error.
+		for _, format := range []string{"jsonl-short", "jsonl-last", "buffer-last", "buffer-full"} {
+			resp := pool.send(Msg{"type": "capture", "sessionId": s3, "format": format})
+			assertError(t, resp)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- **Fix queued = no UUID falsehood**: re-queued sessions (offloaded → queued via followup/pin) retain their UUID. Updated SPEC, protocol.md, schema. JSONL capture now works on queued sessions with a UUID.
- **Add Session Lifecycle Mechanics** to SPEC Internals: documents `/clear` + `/resume` reuse model — pool never spawns new Claude processes because it kills bash output for other sessions.
- **Fill test gaps** identified during SPEC audit:
  - `slots_test.go`: capture on fresh-queued session errors
  - `offload_test.go`: stop on offloaded/archived errors, process death → offloaded, wait returns error on session death
  - Extract `killPID` helper to helpers_test.go
- **Defer error_test.go**: no reliable way to trigger repeated load failures. Removed from CLAUDE.md table with explanation.
- **Document Claude Code cd constraint** in testing docs.

## Test plan

- [ ] `go vet ./...` passes
- [ ] New tests compile and follow flow-based test patterns
- [ ] SPEC, protocol.md, and schema are consistent on queued-UUID behavior