### PR TITLE
Harden session lifecycle, fix bugs, clean up code

### DIFF
--- a/cmd/claude-pool/main.go
+++ b/cmd/claude-pool/main.go
@@ -41,6 +41,8 @@ func main() {
 	mgr := pool.NewManager(p, cfgMgr)
 
 	srv := api.NewServer(p.Socket(), mgr.Handle)
+	srv.OnDisconnect(mgr.HandleDisconnect)
+	mgr.SetConnAcceptedAt(srv.ConnAcceptedAt)
 	if err := srv.Start(); err != nil {
 		log.Fatalf("failed to start API server: %v", err)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -8,21 +8,25 @@ import (
 	"net"
 	"os"
 	"sync"
+	"time"
 )
 
 // Handler processes a request and returns a response.
-// For subscribe requests, it should return nil and handle the connection directly.
+// Returning nil means "no response to write" (e.g., subscribe mode).
 type Handler func(conn net.Conn, req Msg) Msg
 
 // Server is the Unix socket API server.
 type Server struct {
-	socketPath string
-	listener   net.Listener
-	handler    Handler
-	wg         sync.WaitGroup
-	done       chan struct{}
-	conns      map[net.Conn]struct{}
-	connsMu    sync.Mutex
+	socketPath   string
+	listener     net.Listener
+	handler      Handler
+	onDisconnect func(net.Conn) // called when a connection closes
+	wg           sync.WaitGroup
+	done         chan struct{}
+
+	connsMu   sync.Mutex
+	conns     map[net.Conn]struct{}
+	connTimes map[net.Conn]time.Time // when each connection was accepted
 }
 
 func NewServer(socketPath string, handler Handler) *Server {
@@ -31,20 +35,35 @@ func NewServer(socketPath string, handler Handler) *Server {
 		handler:    handler,
 		done:       make(chan struct{}),
 		conns:      make(map[net.Conn]struct{}),
+		connTimes:  make(map[net.Conn]time.Time),
 	}
+}
+
+// OnDisconnect registers a callback invoked when a connection closes.
+func (s *Server) OnDisconnect(fn func(net.Conn)) {
+	s.onDisconnect = fn
+}
+
+// ConnAcceptedAt returns when a connection was accepted. Used by subscribers
+// to determine the replay boundary — only events after this time are replayed.
+func (s *Server) ConnAcceptedAt(conn net.Conn) time.Time {
+	s.connsMu.Lock()
+	t := s.connTimes[conn]
+	s.connsMu.Unlock()
+	if t.IsZero() {
+		return time.Now()
+	}
+	return t
 }
 
 // Start begins listening on the Unix socket.
 func (s *Server) Start() error {
-	// Remove stale socket if it exists
 	os.Remove(s.socketPath)
 
 	ln, err := net.Listen("unix", s.socketPath)
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", s.socketPath, err)
 	}
-
-	// Owner-only permissions
 	if err := os.Chmod(s.socketPath, 0600); err != nil {
 		ln.Close()
 		return fmt.Errorf("chmod socket: %w", err)
@@ -61,8 +80,7 @@ func (s *Server) Start() error {
 	return nil
 }
 
-// Stop closes the listener, removes the socket (so clients see it's gone immediately),
-// then waits for active connections to drain.
+// Stop closes the listener, removes the socket, then waits for connections to drain.
 func (s *Server) Stop() {
 	close(s.done)
 	if s.listener != nil {
@@ -70,7 +88,6 @@ func (s *Server) Stop() {
 	}
 	os.Remove(s.socketPath)
 
-	// Close all tracked connections so handleConn goroutines unblock
 	s.connsMu.Lock()
 	for conn := range s.conns {
 		conn.Close()
@@ -92,6 +109,13 @@ func (s *Server) acceptLoop() {
 				continue
 			}
 		}
+
+		now := time.Now()
+		s.connsMu.Lock()
+		s.conns[conn] = struct{}{}
+		s.connTimes[conn] = now
+		s.connsMu.Unlock()
+
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
@@ -101,22 +125,18 @@ func (s *Server) acceptLoop() {
 }
 
 func (s *Server) handleConn(conn net.Conn) {
-	s.connsMu.Lock()
-	s.conns[conn] = struct{}{}
-	s.connsMu.Unlock()
-
-	owned := false // set when handler takes ownership (e.g., subscribe)
 	defer func() {
-		if !owned {
-			s.connsMu.Lock()
-			delete(s.conns, conn)
-			s.connsMu.Unlock()
-			conn.Close()
+		if s.onDisconnect != nil {
+			s.onDisconnect(conn)
 		}
+		s.connsMu.Lock()
+		delete(s.conns, conn)
+		delete(s.connTimes, conn)
+		s.connsMu.Unlock()
+		conn.Close()
 	}()
 
 	scanner := bufio.NewScanner(conn)
-	// Allow large messages (16MB)
 	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
 
 	for scanner.Scan() {
@@ -134,10 +154,7 @@ func (s *Server) handleConn(conn net.Conn) {
 
 		resp := s.handler(conn, req)
 		if resp == nil {
-			// Handler took ownership of connection (e.g., subscribe).
-			// Don't close or untrack — the handler manages it now.
-			owned = true
-			return
+			continue
 		}
 		s.writeMsg(conn, resp)
 	}

--- a/internal/api/subscribe.go
+++ b/internal/api/subscribe.go
@@ -5,42 +5,107 @@ import (
 	"log"
 	"net"
 	"sync"
+	"time"
 )
 
 // Subscriber receives filtered events on a persistent connection.
+//
+// New subscribers start in "pending" mode: events are buffered instead of sent
+// immediately. This handles two cases:
+//   - Race window: a command on another connection may be processed before the
+//     subscribe message, so its event needs to be captured and delivered later.
+//   - Re-subscribe: if the client sends a second subscribe (with different
+//     filters) before the pending buffer is flushed, the buffer is cleared so
+//     events matched by the old filters are discarded.
+//
+// The subscriber transitions to "committed" mode (direct delivery) either when
+// Commit() is called explicitly or after a short timeout.
 type Subscriber struct {
-	conn     net.Conn
-	mu       sync.Mutex
-	sessions map[string]bool // nil = all sessions
-	events   map[string]bool // nil = all events
-	statuses map[string]bool // nil = all statuses (only for "status" events)
-	fields   map[string]bool // nil = all fields (only for "updated" events)
+	conn        net.Conn
+	connectedAt time.Time // connection accept time — replay boundary
+
+	mu        sync.Mutex
+	sessions  map[string]bool // nil = all sessions
+	events    map[string]bool // nil = all events
+	statuses  map[string]bool // nil = all statuses; restricts to "status" events only
+	fields    map[string]bool // nil = all fields; restricts to "updated" events only
+	committed bool
+	pending   []Msg
 }
 
 // NewSubscriber creates a subscriber from subscribe request options.
-func NewSubscriber(conn net.Conn, opts Msg) *Subscriber {
-	s := &Subscriber{conn: conn}
-	s.UpdateFilters(opts)
+// The subscriber starts in pending mode (events are buffered).
+// connectedAt is the time the connection was accepted — only events after
+// this time are replayed from the ring buffer.
+func NewSubscriber(conn net.Conn, opts Msg, connectedAt time.Time) *Subscriber {
+	s := &Subscriber{conn: conn, connectedAt: connectedAt}
+	s.applyFilters(opts)
 	return s
 }
 
-// UpdateFilters replaces the subscriber's filters.
+// UpdateFilters replaces the subscriber's filters, clears any buffered events
+// (which matched the old filters), and commits (switches to direct delivery).
 func (s *Subscriber) UpdateFilters(opts Msg) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.applyFilters(opts)
+	s.pending = nil
+	s.committed = true
+}
+
+// Commit flushes buffered events (re-checking against current filters) and
+// switches to direct delivery. Safe to call multiple times.
+func (s *Subscriber) Commit() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.committed {
+		return
+	}
+	s.committed = true
+
+	for _, event := range s.pending {
+		if s.matchesLocked(event) {
+			s.directSend(event)
+		}
+	}
+	s.pending = nil
+}
+
+// Matches returns true if the event passes all filters (ANDed).
+func (s *Subscriber) Matches(event Msg) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.matchesLocked(event)
+}
+
+// Send delivers an event. In pending mode, events are buffered.
+// In committed mode, events are sent directly to the connection.
+func (s *Subscriber) Send(event Msg) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.committed {
+		s.pending = append(s.pending, event)
+		return nil
+	}
+	return s.directSend(event)
+}
+
+// Conn returns the underlying connection.
+func (s *Subscriber) Conn() net.Conn {
+	return s.conn
+}
+
+func (s *Subscriber) applyFilters(opts Msg) {
 	s.sessions = toStringSet(opts["sessions"])
 	s.events = toStringSet(opts["events"])
 	s.statuses = toStringSet(opts["statuses"])
 	s.fields = toStringSet(opts["fields"])
 }
 
-// Matches returns true if the event passes all filters.
-func (s *Subscriber) Matches(event Msg) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// Session filter
+func (s *Subscriber) matchesLocked(event Msg) bool {
 	if s.sessions != nil {
 		sid, _ := event["sessionId"].(string)
 		if !s.sessions[sid] {
@@ -48,7 +113,6 @@ func (s *Subscriber) Matches(event Msg) bool {
 		}
 	}
 
-	// Event type filter
 	eventType, _ := event["event"].(string)
 	if s.events != nil {
 		if !s.events[eventType] {
@@ -56,16 +120,20 @@ func (s *Subscriber) Matches(event Msg) bool {
 		}
 	}
 
-	// Status filter (only for "status" events)
-	if s.statuses != nil && eventType == "status" {
+	if s.statuses != nil {
+		if eventType != "status" {
+			return false
+		}
 		status, _ := event["status"].(string)
 		if !s.statuses[status] {
 			return false
 		}
 	}
 
-	// Fields filter (only for "updated" events)
-	if s.fields != nil && eventType == "updated" {
+	if s.fields != nil {
+		if eventType != "updated" {
+			return false
+		}
 		changes, ok := event["changes"].(Msg)
 		if !ok {
 			return false
@@ -85,8 +153,7 @@ func (s *Subscriber) Matches(event Msg) bool {
 	return true
 }
 
-// Send writes an event to the subscriber's connection.
-func (s *Subscriber) Send(event Msg) error {
+func (s *Subscriber) directSend(event Msg) error {
 	data, err := json.Marshal(event)
 	if err != nil {
 		return err
@@ -96,25 +163,25 @@ func (s *Subscriber) Send(event Msg) error {
 	return err
 }
 
-// Conn returns the underlying connection.
-func (s *Subscriber) Conn() net.Conn {
-	return s.conn
+// recentEvent pairs an event with its broadcast timestamp.
+type recentEvent struct {
+	event Msg
+	at    time.Time
 }
 
-// SubscriberHub manages all active subscribers and maintains a short
-// replay buffer so new subscribers receive events they narrowly missed
-// (race between subscribe registration and event broadcasting).
+// SubscriberHub manages active subscribers, broadcasts events, and maintains
+// a short ring buffer so that events from the race window between connection
+// accept and subscribe processing can be replayed.
 type SubscriberHub struct {
 	mu   sync.Mutex
 	subs map[*Subscriber]struct{}
 
-	// Ring buffer for recent events (fixed-size, no slice shifting)
-	ring    [replayBufferSize]Msg
-	ringPos int // next write position
-	ringLen int // number of valid entries (0..replayBufferSize)
+	ring    [replayBufferSize]recentEvent
+	ringPos int
+	ringLen int
 }
 
-const replayBufferSize = 100
+const replayBufferSize = 64
 
 // NewSubscriberHub creates a new hub.
 func NewSubscriberHub() *SubscriberHub {
@@ -123,21 +190,29 @@ func NewSubscriberHub() *SubscriberHub {
 	}
 }
 
-// Add registers a subscriber and replays recent events that match its filters.
-// Holding the lock during both registration and replay ensures no event is
-// delivered twice (via both replay and live broadcast).
+// Add registers a subscriber and replays recent events from the ring buffer.
+// Replayed events go to the subscriber's pending buffer (not sent directly).
+// Call Commit() after a short delay to flush; if a re-subscribe arrives first,
+// UpdateFilters() clears the buffer so stale-filter events are discarded.
 func (h *SubscriberHub) Add(s *Subscriber) {
 	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	h.subs[s] = struct{}{}
-	// Replay recent events in chronological order
+
+	// Replay events from the race window (after connection accept) into
+	// the subscriber's pending buffer. The pending buffer is flushed on
+	// Commit() or cleared on re-subscribe (UpdateFilters).
 	start := (h.ringPos - h.ringLen + replayBufferSize) % replayBufferSize
 	for i := 0; i < h.ringLen; i++ {
-		event := h.ring[(start+i)%replayBufferSize]
-		if s.Matches(event) {
-			s.Send(event)
+		re := h.ring[(start+i)%replayBufferSize]
+		if !re.at.After(s.connectedAt) {
+			continue // event predates this connection
+		}
+		if s.Matches(re.event) {
+			s.Send(re.event) // goes to pending buffer (subscriber is uncommitted)
 		}
 	}
-	h.mu.Unlock()
 }
 
 // Remove unregisters a subscriber.
@@ -147,24 +222,45 @@ func (h *SubscriberHub) Remove(s *Subscriber) {
 	h.mu.Unlock()
 }
 
-// Broadcast sends an event to all matching subscribers and stores it
-// in the replay buffer for late-arriving subscribers.
+// FindByConn returns the subscriber for a given connection, or nil.
+func (h *SubscriberHub) FindByConn(conn net.Conn) *Subscriber {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for s := range h.subs {
+		if s.Conn() == conn {
+			return s
+		}
+	}
+	return nil
+}
+
+// RemoveByConn removes the subscriber for a given connection, if any.
+func (h *SubscriberHub) RemoveByConn(conn net.Conn) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for s := range h.subs {
+		if s.Conn() == conn {
+			delete(h.subs, s)
+			return
+		}
+	}
+}
+
+// Broadcast sends an event to all matching subscribers and stores it in
+// the ring buffer for replay to future subscribers.
 func (h *SubscriberHub) Broadcast(event Msg) {
 	h.mu.Lock()
-	// Store in ring buffer
-	h.ring[h.ringPos] = event
+	h.ring[h.ringPos] = recentEvent{event: event, at: time.Now()}
 	h.ringPos = (h.ringPos + 1) % replayBufferSize
 	if h.ringLen < replayBufferSize {
 		h.ringLen++
 	}
-	// Snapshot current subscribers
 	subs := make([]*Subscriber, 0, len(h.subs))
 	for s := range h.subs {
 		subs = append(subs, s)
 	}
 	h.mu.Unlock()
 
-	// Send outside the lock to avoid blocking other operations
 	for _, s := range subs {
 		if s.Matches(event) {
 			if err := s.Send(event); err != nil {
@@ -173,6 +269,16 @@ func (h *SubscriberHub) Broadcast(event Msg) {
 			}
 		}
 	}
+}
+
+// CommitAfter schedules a subscriber commit after a short delay.
+// This gives the connection time to process a potential re-subscribe
+// (which clears the buffer and changes filters) before flushing.
+func CommitAfter(s *Subscriber, d time.Duration) {
+	go func() {
+		time.Sleep(d)
+		s.Commit()
+	}()
 }
 
 func toStringSet(v any) map[string]bool {

--- a/internal/pool/attach.go
+++ b/internal/pool/attach.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	ptyPkg "github.com/EliasSchlie/claude-pool/internal/pty"
 )
@@ -19,11 +20,12 @@ type attachPipe struct {
 	listener   net.Listener
 	proc       *ptyPkg.Process
 	sub        chan []byte
-	onInput    func([]byte) // called with raw bytes from client → PTY
+	onInput    func([]byte) // called with raw bytes from client → PTY (for state tracking)
 
-	mu    sync.Mutex
-	conns map[net.Conn]struct{}
-	done  chan struct{}
+	mu      sync.Mutex
+	conns   map[net.Conn]struct{}
+	done    chan struct{}
+	stopped chan struct{} // closed when broadcastLoop exits
 }
 
 func newAttachPipe(sessionID, socketDir string, proc *ptyPkg.Process) (*attachPipe, error) {
@@ -47,6 +49,7 @@ func newAttachPipe(sessionID, socketDir string, proc *ptyPkg.Process) (*attachPi
 		sub:        proc.Subscribe(),
 		conns:      make(map[net.Conn]struct{}),
 		done:       make(chan struct{}),
+		stopped:    make(chan struct{}),
 	}
 
 	go ap.acceptLoop()
@@ -99,11 +102,15 @@ func (ap *attachPipe) acceptLoop() {
 }
 
 // broadcastLoop reads PTY output from the subscriber channel and writes to all clients.
+// On shutdown it closes all client connections, ensuring no stale data is
+// delivered after the pipe is told to stop.
 func (ap *attachPipe) broadcastLoop() {
+	defer close(ap.stopped)
 	for {
 		select {
 		case data, ok := <-ap.sub:
 			if !ok {
+				ap.closeConns()
 				return
 			}
 			// Snapshot connections to avoid holding lock during writes
@@ -121,9 +128,20 @@ func (ap *attachPipe) broadcastLoop() {
 				}
 			}
 		case <-ap.done:
+			ap.closeConns()
 			return
 		}
 	}
+}
+
+// closeConns closes all tracked client connections.
+func (ap *attachPipe) closeConns() {
+	ap.mu.Lock()
+	for conn := range ap.conns {
+		conn.Close()
+		delete(ap.conns, conn)
+	}
+	ap.mu.Unlock()
 }
 
 func (ap *attachPipe) removeConn(conn net.Conn) {
@@ -140,18 +158,26 @@ func (ap *attachPipe) Close() {
 	case <-ap.done:
 		return // already closed
 	default:
-		close(ap.done)
 	}
 
-	ap.listener.Close()
-	ap.proc.Unsubscribe(ap.sub)
-
+	// Set immediate write deadline on all connections to unblock any
+	// pending writes in broadcastLoop (prevents deadlock when the
+	// client isn't reading — e.g., test is waiting for the offload response).
 	ap.mu.Lock()
 	for conn := range ap.conns {
-		conn.Close()
-		delete(ap.conns, conn)
+		conn.SetWriteDeadline(time.Now())
 	}
 	ap.mu.Unlock()
+
+	// Unsubscribe closes the sub channel. The broadcastLoop will see
+	// the closed channel, close all client connections, and exit.
+	ap.proc.Unsubscribe(ap.sub)
+	close(ap.done)
+	ap.listener.Close()
+
+	// Wait for broadcastLoop to finish closing connections. This ensures
+	// the offload response isn't sent until clients have been disconnected.
+	<-ap.stopped
 
 	os.Remove(ap.socketPath)
 	log.Printf("[attach] session %s: pipe closed", ap.sessionID)

--- a/internal/pool/capture.go
+++ b/internal/pool/capture.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -11,12 +12,12 @@ func (m *Manager) captureContent(s *Session, format string) string {
 	switch format {
 	case "buffer-full":
 		if proc := m.procs[s.ID]; proc != nil {
-			return string(proc.Buffer())
+			return stripANSI(string(proc.Buffer()))
 		}
 		return ""
 	case "buffer-last":
 		if proc := m.procs[s.ID]; proc != nil {
-			return extractLastSection(string(proc.Buffer()))
+			return extractLastSection(stripANSI(string(proc.Buffer())))
 		}
 		return ""
 	case "jsonl-full":
@@ -170,4 +171,11 @@ func extractLastSection(buf string) string {
 		lines = lines[len(lines)-50:]
 	}
 	return strings.Join(lines, "\n")
+}
+
+// stripANSI removes ANSI escape sequences from terminal output.
+var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b\[[0-9;]*[mGKHJ]|\x1b[()][0-9A-B]`)
+
+func stripANSI(s string) string {
+	return ansiRegexp.ReplaceAllString(s, "")
 }

--- a/internal/pool/handlers.go
+++ b/internal/pool/handlers.go
@@ -1,7 +1,6 @@
 package pool
 
 import (
-	"encoding/json"
 	"log"
 	"net"
 	"strings"
@@ -225,33 +224,17 @@ func (m *Manager) handleStart(id any, req api.Msg) api.Msg {
 		})
 	}
 
-	// Try to evict an idle session with strictly lower priority
-	if evicted := m.findEvictableSessionBelow(s.Priority); evicted != nil {
-		log.Printf("[start] session %s: evicting idle session %s (priority=%.1f) to free slot", s.ID, evicted.ID, evicted.Priority)
-		m.offloadSessionLocked(evicted)
-		s.Status = StatusFresh
-		m.spawnSession(s, false)
-		s.PendingPrompt = prompt
-		m.deliverPromptWhenReady(s)
-		m.broadcastEvent(api.Msg{
-			"type": "event", "event": "created",
-			"sessionId": s.ID, "status": StatusProcessing, "parentId": s.ParentID,
-		})
-		m.savePoolState()
-		return api.Response(id, "started", api.Msg{
-			"sessionId": s.ID,
-			"status":    StatusProcessing,
-		})
-	}
-
-	// Queue it
-	log.Printf("[start] session %s: no slots available, queuing (queue depth=%d)", s.ID, len(m.queue)+1)
+	// No fresh slot available — queue the request, then try to fill from
+	// available slots. Only evict if all slots are occupied.
+	log.Printf("[start] session %s: no fresh slots, queuing (queue depth=%d)", s.ID, len(m.queue)+1)
 	s.Status = StatusQueued
 	m.queue = append(m.queue, s)
 	m.broadcastEvent(api.Msg{
 		"type": "event", "event": "created",
 		"sessionId": s.ID, "status": s.Status, "parentId": s.ParentID,
 	})
+
+	m.tryDequeueWithEviction(s, "")
 	m.savePoolState()
 
 	return api.Response(id, "started", api.Msg{
@@ -309,20 +292,14 @@ func (m *Manager) handleFollowup(id any, req api.Msg) api.Msg {
 			"status":    s.Status,
 		})
 
-	case StatusOffloaded, StatusDead, StatusError:
+	case StatusOffloaded, StatusError:
 		log.Printf("[followup] session %s: %s → queued for respawn", s.ID, s.Status)
 		s.PendingPrompt = prompt
 		prevStatus := s.Status
 		s.Status = StatusQueued
 		m.queue = append(m.queue, s)
 		m.broadcastStatus(s, prevStatus)
-		// Try to free a slot by offloading the lowest-priority idle session.
-		// Restored sessions have "earned" their slot from prior use.
-		if evicted := m.findEvictableSession(); evicted != nil && evicted.ID != s.ID {
-			log.Printf("[followup] session %s: evicting idle session %s (priority=%.1f) to free slot for respawn", s.ID, evicted.ID, evicted.Priority)
-			m.offloadSessionLocked(evicted)
-		}
-		m.tryDequeue()
+		m.tryDequeueWithEviction(s, s.ID)
 		m.savePoolState()
 		m.mu.Unlock()
 		return api.Response(id, "started", api.Msg{
@@ -330,29 +307,45 @@ func (m *Manager) handleFollowup(id any, req api.Msg) api.Msg {
 			"status":    s.Status,
 		})
 
-	case StatusProcessing, StatusTyping:
+	case StatusProcessing:
 		if !force {
 			m.mu.Unlock()
 			return api.ErrorResponse(id, "session is processing; use force: true to override")
 		}
 		log.Printf("[followup] session %s: force-interrupting %s, sending Ctrl-C (pid=%d)", s.ID, s.Status, s.PID)
-		s.PendingPrompt = prompt
-		s.PendingForce = true
-		pid := s.PID
-		if proc := m.procs[s.ID]; proc != nil {
-			proc.WriteString("\x03")
-		}
+		s.LastUsedAt = time.Now()
+		sid := s.ID
 		m.savePoolState()
 		m.mu.Unlock()
-		// Ctrl-C doesn't trigger a hook — manually write idle signal
-		// so watchIdleSignal picks up the pending force prompt.
-		go func() {
-			time.Sleep(500 * time.Millisecond)
-			m.writeIdleSignal(pid, "ctrl-c")
-		}()
+
+		// Wait for any in-flight prompt delivery to finish before
+		// sending Ctrl-C — otherwise the old prompt's Enter keystroke
+		// arrives after Ctrl-C, starting the old command.
+		m.awaitDelivery(sid)
+
+		m.mu.Lock()
+		proc := m.procs[sid]
+		if proc != nil {
+			proc.WriteString("\x03")
+		}
+		m.mu.Unlock()
+
+		// Give Claude time to process the Ctrl-C: cancel the current
+		// task, write "[Request interrupted by user]", and return to
+		// its prompt. Then deliver the new prompt directly — don't
+		// rely on Stop hook (may not fire reliably for shell builtins).
+		time.Sleep(3 * time.Second)
+
+		m.mu.Lock()
+		s = m.sessions[sid]
+		if s != nil {
+			m.deliverPrompt(s, prompt)
+		}
+		m.mu.Unlock()
+
 		return api.Response(id, "started", api.Msg{
-			"sessionId": s.ID,
-			"status":    s.Status,
+			"sessionId": sid,
+			"status":    StatusProcessing,
 		})
 
 	case StatusQueued:
@@ -429,9 +422,6 @@ func (m *Manager) handleWait(id any, req api.Msg) api.Msg {
 	case StatusArchived:
 		m.mu.Unlock()
 		return api.ErrorResponse(id, "session is archived")
-	case StatusDead:
-		m.mu.Unlock()
-		return api.ErrorResponse(id, "session died")
 	case StatusError:
 		m.mu.Unlock()
 		return api.ErrorResponse(id, "session has error")
@@ -472,9 +462,9 @@ func (m *Manager) handleWait(id any, req api.Msg) api.Msg {
 					"sessionId": sid,
 					"content":   content,
 				})
-			case StatusDead:
+			case StatusOffloaded:
 				m.mu.Unlock()
-				return api.ErrorResponse(id, "session died")
+				return api.ErrorResponse(id, "session is offloaded; use followup to resume")
 			case StatusError:
 				m.mu.Unlock()
 				return api.ErrorResponse(id, "session error")
@@ -503,7 +493,7 @@ func (m *Manager) handleStop(id any, req api.Msg) api.Msg {
 	log.Printf("[stop] session %s: status=%s pid=%d", s.ID, s.Status, s.PID)
 
 	switch s.Status {
-	case StatusIdle, StatusTyping, StatusFresh:
+	case StatusIdle, StatusFresh:
 		log.Printf("[stop] session %s: already %s, nothing to stop", s.ID, s.Status)
 		m.mu.Unlock()
 		return api.OkResponse(id)
@@ -522,41 +512,38 @@ func (m *Manager) handleStop(id any, req api.Msg) api.Msg {
 
 	case StatusProcessing:
 		log.Printf("[stop] session %s: sending Ctrl-C to pid %d", s.ID, s.PID)
-		proc := m.procs[s.ID]
-		if proc != nil {
+		sid := s.ID
+		// Transition directly — Ctrl-C interrupts the bash tool, and we
+		// don't need to wait for a hook round-trip. The next prompt delivery
+		// (Escape → Ctrl-U → text → Enter) resets Claude's input line anyway.
+		prevStatus := s.Status
+		s.Status = StatusIdle
+		s.PendingInput = ""
+		log.Printf("[stop] session %s: processing → idle", s.ID)
+		m.broadcastStatus(s, prevStatus)
+		m.savePoolState()
+		m.mu.Unlock()
+
+		// Wait for any in-flight delivery to finish, then send Ctrl-C
+		m.awaitDelivery(sid)
+		m.mu.Lock()
+		if proc := m.procs[sid]; proc != nil {
 			proc.WriteString("\x03")
 		}
-		// Ctrl-C doesn't trigger a Claude hook — manually transition to idle.
-		// Give Claude a moment to process the interrupt, then write a fresh
-		// idle signal so watchIdleSignal picks it up.
-		pid := s.PID
-		m.mu.Unlock()
-
-		time.Sleep(500 * time.Millisecond)
-		m.writeIdleSignal(pid, "ctrl-c")
-
-		// Wait for watchIdleSignal to pick up the signal and transition status
-		deadline := time.After(10 * time.Second)
-		ticker := time.NewTicker(200 * time.Millisecond)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-deadline:
-				return api.ErrorResponse(id, "stop timeout")
-			case <-ticker.C:
-				m.mu.Lock()
-				s := m.sessions[sessionID]
-				if s == nil || s.Status == StatusIdle || s.Status == StatusDead {
-					m.mu.Unlock()
-					return api.OkResponse(id)
+		// Check if a queued session can claim this now-idle slot.
+		if s := m.sessions[sid]; s != nil && s.Status == StatusIdle {
+			m.serveQueueFromSlot(s)
+			// If the queue still has entries, evict an idle session to
+			// make room — the stopped session is now evictable.
+			if len(m.queue) > 0 {
+				if evicted := m.findEvictableSession(); evicted != nil {
+					m.offloadSessionLocked(evicted)
 				}
-				m.mu.Unlock()
 			}
 		}
-
-	case StatusOffloaded, StatusDead, StatusError, StatusArchived:
+		m.tryDequeue()
 		m.mu.Unlock()
-		return api.ErrorResponse(id, "cannot stop session in state: "+s.Status)
+		return api.OkResponse(id)
 
 	default:
 		m.mu.Unlock()
@@ -683,16 +670,14 @@ func (m *Manager) handleOffload(id any, req api.Msg) api.Msg {
 		return api.ErrorResponse(id, "session not found: "+sessionID)
 	}
 
-	if s.Pinned {
-		log.Printf("[offload] session %s: rejected, session is pinned", s.ID)
-		return api.ErrorResponse(id, "cannot offload pinned session; unpin first")
-	}
-
-	if s.Status != StatusIdle && s.Status != StatusTyping {
-		log.Printf("[offload] session %s: rejected, status=%s (need idle or typing)", s.ID, s.Status)
+	if s.Status != StatusIdle {
+		log.Printf("[offload] session %s: rejected, status=%s (need idle)", s.ID, s.Status)
 		return api.ErrorResponse(id, "can only offload idle sessions (current: "+s.Status+")")
 	}
 
+	if s.Pinned {
+		log.Printf("[offload] session %s: auto-unpinning before offload", s.ID)
+	}
 	log.Printf("[offload] session %s: offloading (pid=%d claude=%s)", s.ID, s.PID, s.ClaudeUUID)
 	m.offloadSessionLocked(s)
 	m.savePoolState()
@@ -731,7 +716,7 @@ func (m *Manager) handleArchive(id any, req api.Msg) api.Msg {
 				return api.ErrorResponse(id, "session has unarchived children; use recursive: true")
 			}
 		}
-	} else {
+	} else if recursive {
 		m.archiveDescendants(s.ID)
 	}
 
@@ -839,17 +824,14 @@ func (m *Manager) handlePin(id any, req api.Msg) api.Msg {
 	s.Pinned = true
 	s.PinExpiry = time.Now().Add(time.Duration(duration) * time.Second)
 
-	if s.Status == StatusOffloaded || s.Status == StatusDead || s.Status == StatusError {
+	responseStatus := s.Status
+	if s.Status == StatusOffloaded || s.Status == StatusError {
 		prevStatus := s.Status
 		s.Status = StatusQueued
+		responseStatus = StatusQueued
 		m.queue = append([]*Session{s}, m.queue...)
 		m.broadcastStatus(s, prevStatus)
-		// Evict an idle session if needed to free a slot for priority load
-		if evicted := m.findEvictableSession(); evicted != nil && evicted.ID != s.ID {
-			log.Printf("[pin] session %s: evicting idle session %s to free slot for reload", s.ID, evicted.ID)
-			m.offloadSessionLocked(evicted)
-		}
-		m.tryDequeue()
+		m.tryDequeueWithEviction(s, s.ID)
 	} else if s.Status == StatusQueued {
 		m.removeFromQueue(s)
 		m.queue = append([]*Session{s}, m.queue...)
@@ -863,7 +845,7 @@ func (m *Manager) handlePin(id any, req api.Msg) api.Msg {
 
 	return api.Response(id, "ok", api.Msg{
 		"sessionId": s.ID,
-		"status":    s.Status,
+		"status":    responseStatus,
 	})
 }
 
@@ -1058,7 +1040,16 @@ func (m *Manager) handleAttach(id any, req api.Msg) api.Msg {
 	})
 }
 
-// handleAttachInput processes raw input from attach pipe clients for typing detection.
+// handleAttachInput processes raw input from attach pipe clients for typing
+// detection and prompt delivery.
+//
+// When Enter is detected, the accumulated text is delivered via deliverPrompt
+// (Escape → Ctrl-U → text → Enter with proper timing) to ensure Claude Code's
+// TUI processes the prompt reliably. Raw PTY writes without this ceremony can
+// be lost when text + Enter arrive in a single chunk.
+// handleAttachInput classifies raw bytes from an attach client and manages
+// pendingInput property and state transitions. Raw bytes always pass through
+// to the PTY (the attach pipe writes them directly).
 func (m *Manager) handleAttachInput(sessionID string, data []byte) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1068,25 +1059,66 @@ func (m *Manager) handleAttachInput(sessionID string, data []byte) {
 		return
 	}
 
-	// Classify input
+	// Classify input and extract printable text
 	hasCtrlU := false
-	hasPrintable := false
+	hasEnter := false
+	var printable []byte
 	for _, b := range data {
-		if b == 0x15 { // Ctrl-U
+		switch {
+		case b == 0x15: // Ctrl-U
 			hasCtrlU = true
-		} else if b >= 0x20 && b != 0x7f { // printable (not DEL)
-			hasPrintable = true
+		case b == '\r' || b == '\n': // Enter
+			hasEnter = true
+		case b >= 0x20 && b != 0x7f: // printable (not DEL)
+			printable = append(printable, b)
 		}
 	}
 
 	switch {
-	case hasCtrlU && s.Status == StatusTyping:
-		s.Status = StatusIdle
-		m.broadcastStatus(s, StatusTyping)
-	case hasPrintable && (s.Status == StatusIdle || s.Status == StatusFresh):
+	case hasCtrlU && s.PendingInput != "":
+		// Clear pending input
+		s.PendingInput = ""
+		s.LastUsedAt = time.Now()
+		delete(m.attachTyping, sessionID)
+		m.broadcastEvent(api.Msg{
+			"type": "event", "event": "updated",
+			"sessionId": s.ID, "changes": api.Msg{"pendingInput": ""},
+		})
+
+	case hasEnter && (s.PendingInput != "" || ((s.Status == StatusIdle || s.Status == StatusFresh) && len(printable) > 0)):
+		// Submit prompt
+		buf := m.attachTyping[sessionID]
+		buf = append(buf, printable...)
+		prompt := string(buf)
+		delete(m.attachTyping, sessionID)
+
+		if prompt == "" {
+			return
+		}
+
+		// Clear pendingInput and transition to processing
+		s.PendingInput = ""
 		prev := s.Status
-		s.Status = StatusTyping
+		s.Status = StatusProcessing
+		s.LastUsedAt = time.Now()
 		m.broadcastStatus(s, prev)
+		m.clearIdleSignals(s.PID)
+		log.Printf("[attach] session %s: prompt submitted via attach (%d chars)", sessionID, len(prompt))
+
+		// Also deliver via the reliable prompt mechanism (Escape → Ctrl-U → text → Enter).
+		// Raw bytes reach the PTY too, but Claude's TUI may not reliably process
+		// raw input without the Escape/Ctrl-U reset sequence.
+		go m.deliverPromptAsync(sessionID, prompt)
+
+	case len(printable) > 0 && (s.Status == StatusIdle || s.Status == StatusFresh):
+		// Accumulate typed text as pendingInput
+		m.attachTyping[sessionID] = append(m.attachTyping[sessionID], printable...)
+		s.PendingInput = string(m.attachTyping[sessionID])
+		s.LastUsedAt = time.Now()
+		m.broadcastEvent(api.Msg{
+			"type": "event", "event": "updated",
+			"sessionId": s.ID, "changes": api.Msg{"pendingInput": s.PendingInput},
+		})
 	}
 }
 
@@ -1112,6 +1144,11 @@ func (m *Manager) handleDestroy(id any, req api.Msg) api.Msg {
 		delete(m.procs, sid)
 		if s := m.sessions[sid]; s != nil {
 			delete(m.pidToSID, s.PID)
+			if s.IsLive() {
+				s.Status = StatusOffloaded
+			}
+			s.PID = 0
+			s.PendingInput = ""
 		}
 	}
 
@@ -1132,21 +1169,21 @@ func (m *Manager) handleDestroy(id any, req api.Msg) api.Msg {
 // --- Subscribe ---
 
 func (m *Manager) handleSubscribe(conn net.Conn, req api.Msg) {
-	log.Printf("[subscribe] new subscriber from %s", conn.RemoteAddr())
-	sub := api.NewSubscriber(conn, req)
-	m.hub.Add(sub)
+	if existing := m.hub.FindByConn(conn); existing != nil {
+		log.Printf("[subscribe] re-subscribe from %s", conn.RemoteAddr())
+		existing.UpdateFilters(req) // clears pending buffer, commits
+		return
+	}
 
-	go func() {
-		defer m.hub.Remove(sub)
-		scanner := json.NewDecoder(conn)
-		for {
-			var msg api.Msg
-			if err := scanner.Decode(&msg); err != nil {
-				return
-			}
-			if t, _ := msg["type"].(string); t == "subscribe" {
-				sub.UpdateFilters(msg)
-			}
-		}
-	}()
+	connectedAt := time.Now()
+	if m.connAcceptedAt != nil {
+		connectedAt = m.connAcceptedAt(conn)
+	}
+
+	log.Printf("[subscribe] new subscriber from %s", conn.RemoteAddr())
+	sub := api.NewSubscriber(conn, req, connectedAt)
+	m.hub.Add(sub)
+	// Commit after a short delay to allow a potential re-subscribe to
+	// clear the buffer and update filters before events are flushed.
+	api.CommitAfter(sub, 10*time.Millisecond)
 }

--- a/internal/pool/lifecycle.go
+++ b/internal/pool/lifecycle.go
@@ -2,7 +2,6 @@ package pool
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -133,6 +132,8 @@ func (m *Manager) offloadSessionLocked(s *Session) {
 	s.Status = StatusOffloaded
 	s.PID = 0
 	s.Pinned = false
+	s.PendingInput = ""
+	delete(m.attachTyping, s.ID)
 	m.broadcastStatus(s, prevStatus)
 }
 
@@ -184,20 +185,45 @@ func (m *Manager) watchProcessDone(sessionID string, proc *ptyPkg.Process) {
 		log.Printf("process exited: session=%s pid=%d exit=%d", sessionID, proc.PID(), exitCode)
 		m.mu.Lock()
 		defer m.mu.Unlock()
-		if sess := m.sessions[sessionID]; sess != nil && sess.IsLive() {
-			prevStatus := sess.Status
-			sess.Status = StatusDead
-			m.broadcastStatus(sess, prevStatus)
+
+		// If the session has been respawned with a new process, this watcher
+		// is stale — don't modify session state or clean up the new process.
+		// This happens when: offload kills process → followup respawns session
+		// → old watchProcessDone fires after new process is already running.
+		currentProc := m.procs[sessionID]
+		stale := currentProc != nil && currentProc != proc
+
+		// Track whether the process was still live (unexpected death) before
+		// we transition status. Intentional exits (offload, archive, destroy)
+		// set the session status before killing — IsLive() is already false.
+		unexpectedDeath := false
+		if !stale {
+			if sess := m.sessions[sessionID]; sess != nil && sess.IsLive() {
+				unexpectedDeath = true
+				prevStatus := sess.Status
+				sess.Status = StatusOffloaded
+				sess.PID = 0
+				sess.PendingInput = ""
+				log.Printf("[process-exit] session %s: %s → offloaded (process died)", sessionID, prevStatus)
+				m.broadcastStatus(sess, prevStatus)
+			}
+			if pipe := m.pipes[sessionID]; pipe != nil {
+				pipe.Close()
+				delete(m.pipes, sessionID)
+			}
+			delete(m.procs, sessionID)
 		}
-		// Close attach pipe on process death
-		if pipe := m.pipes[sessionID]; pipe != nil {
-			pipe.Close()
-			delete(m.pipes, sessionID)
+
+		// Only clean up pidToSID if this watcher still owns the PID.
+		// After transferProcess, the PID maps to the new session —
+		// the old watcher must not remove it.
+		if m.pidToSID[proc.PID()] == sessionID {
+			delete(m.pidToSID, proc.PID())
 		}
-		delete(m.pidToSID, proc.PID())
-		delete(m.procs, sessionID)
 		m.tryDequeue()
-		m.tryReplaceDeadSessions()
+		if unexpectedDeath {
+			m.tryReplaceDeadSessions()
+		}
 	}()
 }
 
@@ -225,58 +251,72 @@ func (m *Manager) watchIdleSignal(sessionID string, pid int) {
 			}
 			m.mu.Unlock()
 
-			// Check for Claude UUID from PID mapping
-			if data, err := os.ReadFile(pidMapPath); err == nil {
-				claudeUUID := strings.TrimSpace(string(data))
-				if claudeUUID != "" {
-					m.mu.Lock()
-					if s := m.sessions[sessionID]; s != nil && s.ClaudeUUID == "" {
-						log.Printf("[idle-watch] session %s: discovered claude UUID %s from pid map", sessionID, claudeUUID)
-						s.ClaudeUUID = claudeUUID
+			// Check for Claude UUID from PID mapping (skip if already known)
+			m.mu.Lock()
+			needUUID := m.sessions[sessionID] != nil && m.sessions[sessionID].ClaudeUUID == ""
+			m.mu.Unlock()
+			if needUUID {
+				if data, err := os.ReadFile(pidMapPath); err == nil {
+					claudeUUID := strings.TrimSpace(string(data))
+					if claudeUUID != "" {
+						m.mu.Lock()
+						if s := m.sessions[sessionID]; s != nil && s.ClaudeUUID == "" {
+							log.Printf("[idle-watch] session %s: discovered claude UUID %s from pid map", sessionID, claudeUUID)
+							s.ClaudeUUID = claudeUUID
+						}
+						m.mu.Unlock()
 					}
-					m.mu.Unlock()
 				}
 			}
 
-			// Check idle signal
+			// Read and process idle signal atomically under the mutex.
+			// This prevents races with handleAttachInput's clearIdleSignals —
+			// without this, the idle-watch could read a stale signal file,
+			// then handleAttachInput sets Processing + clears the file, then
+			// the idle-watch acquires the mutex and falsely transitions to Idle.
+			m.mu.Lock()
 			data, err := os.ReadFile(signalPath)
 			if err != nil {
+				m.mu.Unlock()
 				continue
 			}
+			os.Remove(signalPath)
+			log.Printf("[idle-watch] session %s: read signal file (pid=%d): %s", sessionID, pid, strings.TrimSpace(string(data)))
 
-			// Parse signal JSON for cwd and transcript
-			var sig map[string]any
-			if err := json.Unmarshal(data, &sig); err == nil {
-				if cwd, ok := sig["cwd"].(string); ok && cwd != "" {
-					m.mu.Lock()
-					if s := m.sessions[sessionID]; s != nil && s.Cwd != cwd {
-						s.Cwd = cwd
-						m.broadcastEvent(api.Msg{
-							"type": "event", "event": "updated",
-							"sessionId": s.ID, "changes": api.Msg{"cwd": cwd},
-						})
-					}
-					m.mu.Unlock()
-				}
-				if transcript, ok := sig["transcript"].(string); ok && transcript != "" {
-					m.mu.Lock()
-					if s := m.sessions[sessionID]; s != nil && s.ClaudeUUID == "" {
-						base := filepath.Base(transcript)
-						if uuid := strings.TrimSuffix(base, ".jsonl"); uuid != base {
-							s.ClaudeUUID = uuid
-						}
-					}
-					m.mu.Unlock()
-				}
-			}
-
-			// Session is idle
-			m.mu.Lock()
 			s = m.sessions[sessionID]
 			if s == nil {
 				log.Printf("[idle-watch] session %s: gone, stopping watcher", sessionID)
 				m.mu.Unlock()
 				return
+			}
+
+			// Parse signal JSON for cwd and transcript
+			var sig map[string]any
+			if err := json.Unmarshal(data, &sig); err == nil {
+				if cwd, ok := sig["cwd"].(string); ok && cwd != "" && s.Cwd != cwd {
+					s.Cwd = cwd
+					m.broadcastEvent(api.Msg{
+						"type": "event", "event": "updated",
+						"sessionId": s.ID, "changes": api.Msg{"cwd": cwd},
+					})
+				}
+				if transcript, ok := sig["transcript"].(string); ok && transcript != "" && s.ClaudeUUID == "" {
+					base := filepath.Base(transcript)
+					if uuid := strings.TrimSuffix(base, ".jsonl"); uuid != base {
+						s.ClaudeUUID = uuid
+					}
+				}
+			}
+
+			// Startup signals (session-start, session-clear) are only valid for
+			// Fresh → Idle transitions. If the session is Processing, a startup
+			// signal is stale (arrived after handleAttachInput set Processing)
+			// and must not cause a false Processing → Idle transition.
+			trigger, _ := sig["trigger"].(string)
+			if s.Status == StatusProcessing && (trigger == "session-start" || trigger == "session-clear") {
+				log.Printf("[idle-watch] session %s: ignoring stale %s signal (status=%s)", sessionID, trigger, s.Status)
+				m.mu.Unlock()
+				continue
 			}
 
 			if s.Status == StatusFresh || s.Status == StatusProcessing {
@@ -291,9 +331,10 @@ func (m *Manager) watchIdleSignal(sessionID string, pid int) {
 					s.LastUsedAt = time.Now()
 					log.Printf("[idle-watch] session %s: idle signal received, delivering pending prompt (%d chars)", sessionID, len(prompt))
 					m.broadcastStatus(s, prevStatus)
+					// Register delivery under the lock so awaitDelivery
+					// can't miss it between unlock and goroutine start.
+					m.deliverPrompt(s, prompt)
 					m.mu.Unlock()
-					os.Remove(signalPath)
-					m.deliverPromptAsync(sessionID, prompt)
 					continue
 				}
 
@@ -302,10 +343,11 @@ func (m *Manager) watchIdleSignal(sessionID string, pid int) {
 				log.Printf("[idle-watch] session %s: %s → idle (pid=%d)", sessionID, prevStatus, s.PID)
 				m.broadcastStatus(s, prevStatus)
 				m.savePoolState()
-				os.Remove(signalPath)
 
 				// Check if a queued session can claim this slot
 				m.serveQueueFromSlot(s)
+			} else {
+				log.Printf("[idle-watch] session %s: consumed stale signal (status=%s)", sessionID, s.Status)
 			}
 			m.mu.Unlock()
 		}
@@ -314,9 +356,18 @@ func (m *Manager) watchIdleSignal(sessionID string, pid int) {
 
 // --- Prompt delivery ---
 
-// deliverPrompt sends a prompt to a session's terminal.
+// deliverPrompt sends a prompt to a session's terminal asynchronously.
 // Escape → Ctrl-U → text → brief echo check → Enter.
+// Must be called with m.mu held. Callers that need to wait for delivery
+// can select on m.delivering[s.ID] (closed when the goroutine finishes).
 func (m *Manager) deliverPrompt(s *Session, prompt string) {
+	m.deliverPromptWithSettle(s, prompt, 200*time.Millisecond)
+}
+
+// deliverPromptWithSettle is like deliverPrompt but with a custom settle delay.
+// Use a longer delay after Ctrl-C interrupts, since Claude needs time to
+// process the cancellation and return to its prompt.
+func (m *Manager) deliverPromptWithSettle(s *Session, prompt string, settleDelay time.Duration) {
 	proc := m.procs[s.ID]
 	if proc == nil {
 		log.Printf("[deliver] session %s: no process, skipping prompt delivery", s.ID)
@@ -325,12 +376,23 @@ func (m *Manager) deliverPrompt(s *Session, prompt string) {
 
 	sid := s.ID
 	done := m.done
+	ch := make(chan struct{})
+	m.delivering[sid] = ch
 	go func() {
-		// Short delay to let terminal settle after state transition
+		defer func() {
+			close(ch)
+			m.mu.Lock()
+			if m.delivering[sid] == ch {
+				delete(m.delivering, sid)
+			}
+			m.mu.Unlock()
+		}()
+
+		// Delay to let terminal settle after state transition
 		select {
 		case <-done:
 			return
-		case <-time.After(200 * time.Millisecond):
+		case <-time.After(settleDelay):
 		}
 
 		if err := proc.WriteString("\x1b"); err != nil { // Escape
@@ -362,6 +424,17 @@ func (m *Manager) deliverPrompt(s *Session, prompt string) {
 	}()
 }
 
+// awaitDelivery waits for any in-flight prompt delivery on a session.
+// Must be called WITHOUT m.mu held (it blocks on the goroutine).
+func (m *Manager) awaitDelivery(sessionID string) {
+	m.mu.Lock()
+	ch := m.delivering[sessionID]
+	m.mu.Unlock()
+	if ch != nil {
+		<-ch
+	}
+}
+
 // waitForBufferContent polls the process buffer until it contains the given text,
 // checking only the tail to avoid false matches in scrollback.
 func waitForBufferContent(proc *ptyPkg.Process, text string, timeout time.Duration) bool {
@@ -390,12 +463,13 @@ func waitForBufferContent(proc *ptyPkg.Process, text string, timeout time.Durati
 func (m *Manager) deliverPromptAsync(sessionID, prompt string) {
 	m.mu.Lock()
 	s := m.sessions[sessionID]
-	m.mu.Unlock()
 	if s == nil {
+		m.mu.Unlock()
 		log.Printf("[deliver] session %s gone before prompt delivery", sessionID)
 		return
 	}
 	m.deliverPrompt(s, prompt)
+	m.mu.Unlock()
 }
 
 func (m *Manager) deliverPromptWhenReady(s *Session) {
@@ -429,8 +503,8 @@ func (m *Manager) deliverPromptWhenReady(s *Session) {
 					sess.Status = StatusProcessing
 					log.Printf("[deliver] session %s: idle → processing, delivering queued prompt (%d chars)", sid, len(prompt))
 					m.broadcastStatus(sess, StatusIdle)
-					m.mu.Unlock()
 					m.deliverPrompt(sess, prompt)
+					m.mu.Unlock()
 					return
 				}
 				m.mu.Unlock()
@@ -476,15 +550,35 @@ func (m *Manager) waitForSessionReady(id any, sid string, timeout time.Duration)
 // (e.g., after Ctrl-C interrupts processing).
 func (m *Manager) writeIdleSignal(pid int, trigger string) {
 	signalPath := m.paths.IdleSignal(pid)
-	signal := fmt.Sprintf(`{"cwd":"%s","session_id":"","transcript":"","ts":%d,"trigger":"%s"}`,
-		m.paths.Root, time.Now().Unix(), trigger)
+	signal := map[string]any{
+		"cwd":        m.paths.Root,
+		"session_id": "",
+		"transcript": "",
+		"ts":         time.Now().Unix(),
+		"trigger":    trigger,
+	}
+	data, _ := json.Marshal(signal)
 	log.Printf("[idle-signal] writing synthetic idle signal for pid %d (trigger=%s)", pid, trigger)
-	if err := os.WriteFile(signalPath, []byte(signal+"\n"), 0600); err != nil {
+	if err := os.WriteFile(signalPath, append(data, '\n'), 0600); err != nil {
 		log.Printf("[idle-signal] error writing signal for pid %d: %v", pid, err)
 	}
 }
 
 // --- Queue management ---
+
+// tryDequeueWithEviction attempts to dequeue a session by first trying free
+// slots, then evicting an idle session if needed. excludeID prevents evicting
+// the session itself (e.g., during followup/pin). Must be called with m.mu held.
+func (m *Manager) tryDequeueWithEviction(s *Session, excludeID string) {
+	m.tryDequeue()
+	if s.Status == StatusQueued {
+		if evicted := m.findEvictableSession(); evicted != nil && evicted.ID != excludeID {
+			log.Printf("[evict] evicting idle session %s (priority=%.1f) to free slot for %s", evicted.ID, evicted.Priority, s.ID)
+			m.offloadSessionLocked(evicted)
+		}
+		m.tryDequeue()
+	}
+}
 
 func (m *Manager) removeFromQueue(s *Session) {
 	for i, q := range m.queue {
@@ -614,40 +708,54 @@ func (m *Manager) clearIdleSignals(pid int) {
 func (m *Manager) findFreshSlot() *Session {
 	// Only claim pre-warmed sessions (pool-owned, never used by a client).
 	// Prefer idle (ready) over fresh (still starting).
+	var freshCandidate *Session
 	for _, s := range m.sessions {
-		if s.PreWarmed && s.Status == StatusIdle && !s.Pinned {
-			return s
+		if !s.PreWarmed || s.Pinned {
+			continue
+		}
+		if s.Status == StatusIdle {
+			return s // best case — immediately ready
+		}
+		if s.Status == StatusFresh && freshCandidate == nil {
+			freshCandidate = s
 		}
 	}
-	for _, s := range m.sessions {
-		if s.PreWarmed && s.Status == StatusFresh && !s.Pinned {
-			return s
-		}
-	}
-	return nil
+	return freshCandidate
 }
 
+// findEvictableSession returns the lowest-priority idle unpinned session,
+// or nil if none qualifies. Among equal-priority sessions, pre-warmed sessions
+// are evicted first, then empty pendingInput, then oldest LRU.
 func (m *Manager) findEvictableSession() *Session {
-	return m.findEvictableSessionBelow(float64(1 << 53)) // effectively no ceiling
-}
-
-// findEvictableSessionBelow returns the lowest-priority idle unpinned session
-// with priority strictly below maxPriority, or nil if none qualifies.
-func (m *Manager) findEvictableSessionBelow(maxPriority float64) *Session {
 	var best *Session
 	for _, s := range m.sessions {
 		if s.Status != StatusIdle || s.Pinned {
 			continue
 		}
-		if s.Priority >= maxPriority {
-			continue
-		}
-		if best == nil || s.Priority < best.Priority ||
-			(s.Priority == best.Priority && s.LastUsedAt.Before(best.LastUsedAt)) {
+		if best == nil || evictsBefore(s, best) {
 			best = s
 		}
 	}
 	return best
+}
+
+// evictsBefore returns true if a should be evicted before b.
+// Order: lower priority → pre-warmed → empty pendingInput → oldest LRU.
+func evictsBefore(a, b *Session) bool {
+	if a.Priority != b.Priority {
+		return a.Priority < b.Priority
+	}
+	// Pre-warmed sessions evicted before user sessions
+	if a.PreWarmed != b.PreWarmed {
+		return a.PreWarmed
+	}
+	// Sessions with empty pendingInput evicted before those with pending text
+	aHasInput := a.PendingInput != ""
+	bHasInput := b.PendingInput != ""
+	if aHasInput != bHasInput {
+		return !aHasInput // evict the one WITHOUT input first
+	}
+	return a.LastUsedAt.Before(b.LastUsedAt)
 }
 
 // tryReplaceDeadSessions spawns new sessions to maintain pool size when

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/EliasSchlie/claude-pool/internal/api"
 	"github.com/EliasSchlie/claude-pool/internal/paths"
@@ -28,13 +29,18 @@ type Manager struct {
 	config *ConfigManager
 	hub    *api.SubscriberHub
 
+	// connAcceptedAt returns when a connection was accepted by the server.
+	connAcceptedAt func(net.Conn) time.Time
+
 	mu             sync.Mutex
 	initialized    bool
 	poolSize       int
 	sessions       map[string]*Session
 	procs          map[string]*ptyPkg.Process
 	pidToSID       map[int]string
-	pipes          map[string]*attachPipe // sessionID → attach pipe
+	pipes          map[string]*attachPipe   // sessionID → attach pipe
+	attachTyping   map[string][]byte        // sessionID → text typed via attach (for prompt delivery on Enter)
+	delivering     map[string]chan struct{} // sessionID → closed when in-flight deliverPrompt completes
 	queue          []*Session
 	killTokens     int
 	done           chan struct{}
@@ -43,20 +49,32 @@ type Manager struct {
 
 func NewManager(p *paths.Pool, cfg *ConfigManager) *Manager {
 	return &Manager{
-		paths:    p,
-		config:   cfg,
-		hub:      api.NewSubscriberHub(),
-		sessions: make(map[string]*Session),
-		procs:    make(map[string]*ptyPkg.Process),
-		pidToSID: make(map[int]string),
-		pipes:    make(map[string]*attachPipe),
-		done:     make(chan struct{}),
+		paths:        p,
+		config:       cfg,
+		hub:          api.NewSubscriberHub(),
+		sessions:     make(map[string]*Session),
+		procs:        make(map[string]*ptyPkg.Process),
+		pidToSID:     make(map[int]string),
+		pipes:        make(map[string]*attachPipe),
+		attachTyping: make(map[string][]byte),
+		delivering:   make(map[string]chan struct{}),
+		done:         make(chan struct{}),
 	}
+}
+
+// SetConnAcceptedAt provides the function that returns when a connection was accepted.
+func (m *Manager) SetConnAcceptedAt(fn func(net.Conn) time.Time) {
+	m.connAcceptedAt = fn
 }
 
 // Done returns a channel that's closed when the pool is destroyed.
 func (m *Manager) Done() <-chan struct{} {
 	return m.done
+}
+
+// HandleDisconnect cleans up subscriber state when a connection closes.
+func (m *Manager) HandleDisconnect(conn net.Conn) {
+	m.hub.RemoveByConn(conn)
 }
 
 // Shutdown performs cleanup on daemon exit.

--- a/internal/pool/persistence.go
+++ b/internal/pool/persistence.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/EliasSchlie/claude-pool/internal/hooks"
@@ -53,6 +54,7 @@ func (m *Manager) savePoolState() {
 			"spawnCwd":   s.SpawnCwd,
 			"cwd":        s.Cwd,
 			"createdAt":  s.CreatedAt.UTC().Format(time.RFC3339),
+			"lastUsedAt": s.LastUsedAt.UTC().Format(time.RFC3339),
 			"flags":      s.Flags,
 			"pinned":     s.Pinned,
 		}
@@ -65,8 +67,14 @@ func (m *Manager) savePoolState() {
 		log.Printf("[persist] error marshaling pool state: %v", err)
 		return
 	}
-	if err := os.WriteFile(m.paths.PoolJSON(), append(data, '\n'), 0644); err != nil {
-		log.Printf("[persist] error writing pool.json: %v", err)
+	// Atomic write: temp file + rename prevents corruption on crash mid-write
+	tmpPath := m.paths.PoolJSON() + ".tmp"
+	if err := os.WriteFile(tmpPath, append(data, '\n'), 0644); err != nil {
+		log.Printf("[persist] error writing pool.json.tmp: %v", err)
+		return
+	}
+	if err := os.Rename(tmpPath, m.paths.PoolJSON()); err != nil {
+		log.Printf("[persist] error renaming pool.json.tmp → pool.json: %v", err)
 	}
 }
 
@@ -107,6 +115,11 @@ func (m *Manager) loadPoolState() (live, offloaded []*Session) {
 			m.sessions[s.ID] = s
 		}
 	}
+	// Sort offloaded sessions: most recently used first, so user-started
+	// sessions get restored into slots before unused pre-warmed ones.
+	sort.Slice(offloaded, func(i, j int) bool {
+		return offloaded[i].LastUsedAt.After(offloaded[j].LastUsedAt)
+	})
 	return live, offloaded
 }
 
@@ -130,6 +143,11 @@ func (m *Manager) sessionFromMap(sm map[string]any) *Session {
 	if t := strVal(sm, "createdAt"); t != "" {
 		if parsed, err := time.Parse(time.RFC3339, t); err == nil {
 			s.CreatedAt = parsed
+		}
+	}
+	if t := strVal(sm, "lastUsedAt"); t != "" {
+		if parsed, err := time.Parse(time.RFC3339, t); err == nil {
+			s.LastUsedAt = parsed
 		}
 	}
 	if s.CreatedAt.IsZero() {

--- a/internal/pool/session.go
+++ b/internal/pool/session.go
@@ -11,28 +11,27 @@ const (
 	StatusQueued     = "queued"
 	StatusFresh      = "fresh" // Pre-warmed, not yet idle (startup in progress)
 	StatusIdle       = "idle"
-	StatusTyping     = "typing"
 	StatusProcessing = "processing"
 	StatusOffloaded  = "offloaded"
-	StatusDead       = "dead"
 	StatusError      = "error"
 	StatusArchived   = "archived"
 )
 
 // Session represents a managed Claude Code session.
 type Session struct {
-	ID         string
-	ClaudeUUID string
-	Status     string
-	ParentID   string
-	Priority   float64
-	Pinned     bool
-	PinExpiry  time.Time // TODO: not yet enforced — no goroutine checks for expiration
-	SpawnCwd   string
-	Cwd        string
-	CreatedAt  time.Time
-	LastUsedAt time.Time // updated on prompt delivery, used for LRU eviction
-	PID        int
+	ID           string
+	ClaudeUUID   string
+	Status       string
+	ParentID     string
+	Priority     float64
+	Pinned       bool
+	PinExpiry    time.Time // TODO: not yet enforced — no goroutine checks for expiration
+	SpawnCwd     string
+	Cwd          string
+	CreatedAt    time.Time
+	LastUsedAt   time.Time // updated on prompt delivery, used for LRU eviction
+	PID          int
+	PendingInput string // Un-submitted text in terminal buffer (attach pipe)
 
 	// Internal: pool-owned pre-warmed session (can be claimed by start/pin)
 	PreWarmed bool
@@ -48,7 +47,7 @@ type Session struct {
 // IsLive returns true if the session has a live terminal.
 func (s *Session) IsLive() bool {
 	switch s.Status {
-	case StatusFresh, StatusIdle, StatusTyping, StatusProcessing:
+	case StatusFresh, StatusIdle, StatusProcessing:
 		return true
 	}
 	return false
@@ -92,6 +91,10 @@ func (s *Session) ToMsg() map[string]any {
 	}
 	if s.PID != 0 {
 		m["pid"] = float64(s.PID)
+	}
+	// Always include pendingInput for loaded sessions (empty string = nothing typed)
+	if s.IsLive() {
+		m["pendingInput"] = s.PendingInput
 	}
 	return m
 }

--- a/internal/pty/pty.go
+++ b/internal/pty/pty.go
@@ -113,9 +113,13 @@ func (p *Process) Exited() bool {
 
 // ExitCode returns the process exit code, or -1 if not yet exited.
 func (p *Process) ExitCode() int {
-	if p.cmd.ProcessState == nil {
+	p.mu.Lock()
+	exited := p.exited
+	p.mu.Unlock()
+	if !exited {
 		return -1
 	}
+	// Safe: ProcessState is immutable after cmd.Wait() returns.
 	return p.cmd.ProcessState.ExitCode()
 }
 
@@ -140,10 +144,17 @@ func (p *Process) Kill() error {
 	if p.cmd.Process == nil {
 		return nil
 	}
-	return p.cmd.Process.Kill()
+	// Best-effort: process may have already exited.
+	err := p.cmd.Process.Kill()
+	if err != nil && p.Exited() {
+		return nil
+	}
+	return err
 }
 
-// Close cleans up the PTY.
+// Close cleans up the PTY. Closing the fd causes readLoop to exit,
+// which stops broadcasting. Subscribers should be cleaned up via
+// Unsubscribe before or after Close.
 func (p *Process) Close() {
 	p.ptmx.Close()
 }


### PR DESCRIPTION
## Summary

Cherry-pick of phase2-sessions commit `051d3de` onto main. The base phase2 code was already merged in #20.

- Rework subscribe system (re-subscribe, connection-aware timestamps, commit buffering)
- Rework attach input handling (pendingInput property, prompt delivery on Enter)  
- Rework force-followup (await delivery before Ctrl-C, direct prompt delivery)
- Rework stop handler (synchronous transition, serve queue after stop)
- Add `connAcceptedAt`, `attachTyping`, `delivering` fields to Manager
- Fix offload to auto-unpin instead of rejecting pinned sessions
- Fix destroy to transition live sessions to offloaded before cleanup
- Add ANSI stripping for buffer capture formats

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/pool/ -v` — unit tests pass (except known bugs #1/#3)
- [ ] Integration tests pass with real daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)