### PR TITLE
Redesign capture API: source/turns/detail params

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -74,36 +74,22 @@ Integer. Default: `1`.
 - `N` — last N turns.
 - `0` — entire history.
 
-A **turn** is one user message and everything that follows until the next user message (assistant responses, tool calls, tool results). For buffer source, turn boundaries are detected from the JSONL transcript — `turns: 1` returns terminal output since the last user message was sent.
+A **turn** is one user message and everything that follows until the next user message (assistant responses, tool calls, tool results).
 
 #### `detail` — what to include per turn (JSONL only)
 
-In Claude Code's JSONL transcripts, tool use and tool results are not separate entry types — `tool_use` blocks appear inside `type: "assistant"` entries, and `tool_result` blocks appear inside `type: "user"` entries. The `detail` parameter filters at both the entry level (which entries to include) and the content-block level (which blocks within an entry to keep).
+| Value | Description |
+|-------|-------------|
+| `"last"` (default) | User prompt + final assistant response per turn. No tool calls. |
+| `"assistant"` | User prompt + all assistant text responses per turn. No tool calls. |
+| `"tools"` | User prompt + assistant responses + tool calls/results. No internal metadata. |
+| `"raw"` | Everything unfiltered. |
 
-| Value | Entries included | Content filtering |
-|-------|-----------------|-------------------|
-| `"last"` (default) | User prompts + final assistant entry with text, per turn. | Strip tool_use blocks. Exclude tool_result user entries. |
-| `"assistant"` | User prompts + all assistant entries that contain text. | Strip tool_use blocks. Exclude tool_result user entries. |
-| `"tools"` | All user entries (prompts + tool results) + all assistant entries. | Keep everything. Strip metadata (model, usage, timestamps). |
-| `"raw"` | All entries unfiltered (including progress, system, etc.). | No filtering. |
+For buffer source, `detail` is ignored — buffer is always raw terminal text.
 
-For buffer source, `detail` is ignored — buffer output is always raw terminal text. The only parameter that affects buffer output is `turns`.
+Empty content is valid — if a session was stopped before producing output, capture might return an empty string.
 
-#### Output format
-
-For JSONL source, the `content` field is always JSONL (one JSON object per line), regardless of `detail` level. The `detail` parameter controls which entries are included and how they are filtered, not the output format.
-
-Example — `source: "jsonl", turns: 2, detail: "last"`:
-```jsonl
-{"type":"user","content":"What is 2+2?"}
-{"type":"assistant","content":"4"}
-{"type":"user","content":"What is 3+3?"}
-{"type":"assistant","content":"6"}
-```
-
-The same request with `detail: "tools"` would include all entries from those turns — including assistant entries with `tool_use` content blocks and user entries carrying `tool_result` blocks.
-
-For buffer source, `content` is plain text (the raw terminal output for the requested turns, ANSI stripped).
+See [docs/protocol.md](docs/protocol.md) for output format details and filtering mechanics.
 
 #### Notes
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -40,41 +40,54 @@ Sessions track their parent. Auto-detected via `CLAUDE_POOL_SESSION_ID` env var,
 
 ## Output Capture
 
-Commands that return session output (`wait`, `capture`) accept three optional parameters:
+Commands that return session output (`wait`, `capture`) accept three optional parameters. See [SPEC.md](../SPEC.md) for the parameter definitions. This section covers implementation details.
 
-### `source` — where to read from
+### JSONL transcript structure
 
-| Value | Description | Requires live terminal? |
-|-------|-------------|------------------------|
-| `"jsonl"` (default) | Claude Code's JSONL transcript (via Claude UUID). Works for any session state where a UUID has been discovered — including offloaded, error, and archived sessions. | No |
-| `"buffer"` | Raw terminal scrollback, ANSI stripped. Only works for live sessions (idle, processing). Errors for queued, offloaded, error, and archived sessions. | Yes |
+Claude Code's JSONL transcripts use these entry types:
 
-### `turns` — how far back to look
+| Entry `type` | Meaning |
+|-------------|---------|
+| `user` | User prompt OR tool result (distinguished by content blocks) |
+| `assistant` | Assistant response OR tool use (distinguished by content blocks) |
+| `progress` | Hook execution, internal events |
+| `system` | System messages |
+| `file-history-snapshot` | File state snapshots |
 
-Integer. Default: `1`.
+Tool calls are **not** separate entry types. A `tool_use` block appears inside an `assistant` entry's `message.content` array. A `tool_result` block appears inside a `user` entry's `message.content` array.
 
-- `1` — last turn only. (default)
-- `N` — last N turns.
-- `0` — entire history.
+### Turn boundaries
 
-A **turn** is one user message and everything that follows until the next user message (assistant responses, tool calls, tool results). For buffer source, turn boundaries are detected from the JSONL transcript — `turns: 1` returns terminal output since the last user message was sent.
+A turn starts at a user prompt (a `type: "user"` entry where `message.content` contains a `text` block, not a `tool_result` block) and includes everything until the next user prompt. For buffer source, turn boundaries are detected from the JSONL transcript — `turns: 1` returns terminal output since the last user prompt was sent.
 
-### `detail` — what to include per turn (JSONL only)
+### Detail filtering
 
-In Claude Code's JSONL transcripts, tool use and tool results are not separate entry types — `tool_use` blocks appear inside `type: "assistant"` entries, and `tool_result` blocks appear inside `type: "user"` entries. The `detail` parameter filters at both the entry level (which entries to include) and the content-block level (which blocks within an entry to keep).
+The `detail` parameter filters at two levels: which entries to include, and which content blocks to keep within each entry.
 
 | Value | Entries included | Content filtering |
 |-------|-----------------|-------------------|
-| `"last"` (default) | User prompts + final assistant entry with text, per turn. | Strip tool_use blocks. Exclude tool_result user entries. |
-| `"assistant"` | User prompts + all assistant entries that contain text. | Strip tool_use blocks. Exclude tool_result user entries. |
-| `"tools"` | All user entries (prompts + tool results) + all assistant entries. | Keep everything. Strip metadata (model, usage, timestamps). |
+| `"last"` | User prompts + final assistant entry with text, per turn. | Exclude tool_use blocks. Exclude tool_result user entries. |
+| `"assistant"` | User prompts + all assistant entries that contain text. | Exclude tool_use blocks. Exclude tool_result user entries. |
+| `"tools"` | All user entries (prompts + tool results) + all assistant entries. | Keep all content blocks. Strip metadata fields (see below). |
 | `"raw"` | All entries unfiltered (including progress, system, etc.). | No filtering. |
 
-For buffer source, `detail` is ignored — buffer output is always raw terminal text.
+For buffer source, `detail` is ignored — buffer is always raw terminal text.
+
+### Metadata stripping (`detail: "tools"`)
+
+When `detail` is `"tools"`, the following fields are stripped from each entry to reduce noise while preserving conversation content:
+
+**Stripped from all entries:** `parentUuid`, `isSidechain`, `version`, `gitBranch`, `requestId`, `uuid`, `timestamp`, `cwd`, `sessionId`, `userType`
+
+**Stripped from `message` objects:** `model`, `id`, `usage`, `stop_reason`, `stop_sequence`
+
+**Kept:** `type`, `message.role`, `message.content`
+
+This list may grow as Claude Code evolves. The principle: keep conversation content, strip everything else.
 
 ### Output format
 
-For JSONL source, the `content` field is always JSONL (one JSON object per line), regardless of `detail` level. The `detail` parameter controls which entries are included and how they are filtered, not the output format.
+For JSONL source, the `content` field is always JSONL (one JSON object per line). The `detail` parameter controls which entries are included, not the format.
 
 Example — `source: "jsonl", turns: 2, detail: "last"`:
 ```jsonl
@@ -84,15 +97,15 @@ Example — `source: "jsonl", turns: 2, detail: "last"`:
 {"type":"assistant","content":"6"}
 ```
 
-The same request with `detail: "tools"` would include all entries from those turns — including assistant entries with `tool_use` content blocks and user entries carrying `tool_result` blocks.
+With `detail: "tools"`, the same request would additionally include assistant entries with `tool_use` content blocks and user entries carrying `tool_result` blocks — but with metadata fields removed.
 
-With `detail: "raw"`, entries are the original unmodified JSONL lines from Claude Code's transcript (including `progress`, `system`, `file-history-snapshot` entries, and all metadata fields like `model`, `usage`, `parentUuid`, `timestamp`, etc.).
+With `detail: "raw"`, entries are the original unmodified lines from Claude Code's transcript.
 
-For buffer source, `content` is plain text (the raw terminal output for the requested turns, ANSI stripped).
+For buffer source, `content` is plain text (raw terminal output for the requested turns, ANSI escape sequences stripped).
 
 ### Empty content
 
-If a session was interrupted (`stop`) before Claude produced any assistant output, or if there is no assistant message in the requested turns, capture might return an empty string. This is not an error — it reflects that no output was produced. Callers should handle empty content gracefully.
+If a session was stopped before producing output, or if there is no assistant message in the requested turns, capture returns an empty string. This is not an error. Callers should handle empty content gracefully.
 
 ---
 

--- a/internal/pool/capture.go
+++ b/internal/pool/capture.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// captureOutput is the new capture API with orthogonal source/turns/detail params.
+// captureOutput returns session output filtered by source/turns/detail params.
 // TODO: implement — currently panics to fail tests explicitly.
 func (m *Manager) captureOutput(s *Session, source string, turns int, detail string) string {
 	panic("captureOutput not implemented — see capture API redesign")

--- a/internal/pool/capture_test.go
+++ b/internal/pool/capture_test.go
@@ -383,25 +383,94 @@ func TestCaptureDetailLastToolTurn(t *testing.T) {
 
 // === detail: "assistant" ===
 
-func TestCaptureDetailAssistant(t *testing.T) {
-	// Both turns: should include all assistant text blocks but no tool_use-only entries
-	m, s := setupFakeTranscript(t, "detail-asst", toolUseTranscript(t))
+// multiAssistantTranscript has a turn where the assistant gives text, calls a tool,
+// then gives more text — testing that "assistant" returns all text blocks while
+// "last" returns only the final one.
+func multiAssistantTranscript(t *testing.T) string {
+	return buildTranscript(t,
+		buildEntry(t, "user", "check the logs"),
+		buildEntry(t, "assistant", "let me look at the logs"),
+		buildEntry(t, "assistant_tool_use", "Bash"),
+		buildEntry(t, "tool_result", "ERROR: connection refused"),
+		buildEntry(t, "assistant", "the logs show a connection error"),
+	)
+}
+
+func TestCaptureDetailAssistantReturnsAllTextBlocks(t *testing.T) {
+	// Key distinction from "last": "assistant" returns ALL assistant text blocks,
+	// not just the final one. In a tool-use turn, there are typically multiple.
+	m, s := setupFakeTranscript(t, "detail-asst-multi", multiAssistantTranscript(t))
+	result := m.captureOutput(s, "jsonl", 1, "assistant")
+	entries := parseCaptureLines(t, result)
+
+	// Both assistant text messages should be present
+	mustContain(t, "result", result, "let me look at the logs")
+	mustContain(t, "result", result, "the logs show a connection error")
+
+	// But tool_use and tool_result should be excluded
+	mustNotContain(t, "result", result, "connection refused")
+	for _, e := range entries {
+		if hasContentBlockType(e, "tool_use") {
+			t.Fatal("detail 'assistant' should not include tool_use blocks")
+		}
+		if hasContentBlockType(e, "tool_result") {
+			t.Fatal("detail 'assistant' should not include tool_result entries")
+		}
+	}
+
+	// User prompt present
+	mustContain(t, "result", result, "check the logs")
+}
+
+func TestCaptureDetailLastVsAssistant(t *testing.T) {
+	// Direct comparison: "last" returns 1 assistant, "assistant" returns 2
+	m, s := setupFakeTranscript(t, "last-vs-asst", multiAssistantTranscript(t))
+
+	lastResult := m.captureOutput(s, "jsonl", 1, "last")
+	asstResult := m.captureOutput(s, "jsonl", 1, "assistant")
+
+	lastEntries := parseCaptureLines(t, lastResult)
+	asstEntries := parseCaptureLines(t, asstResult)
+
+	// "last" should have fewer assistant entries than "assistant"
+	lastAssistantCount := countByType(lastEntries, "assistant")
+	asstAssistantCount := countByType(asstEntries, "assistant")
+
+	if lastAssistantCount != 1 {
+		t.Fatalf("detail 'last' should return 1 assistant entry, got %d", lastAssistantCount)
+	}
+	if asstAssistantCount != 2 {
+		t.Fatalf("detail 'assistant' should return 2 assistant entries, got %d", asstAssistantCount)
+	}
+
+	// "last" should only have the final text
+	mustNotContain(t, "last result", lastResult, "let me look")
+	mustContain(t, "last result", lastResult, "connection error")
+
+	// "assistant" should have both
+	mustContain(t, "assistant result", asstResult, "let me look")
+	mustContain(t, "assistant result", asstResult, "connection error")
+}
+
+func TestCaptureDetailAssistantExcludesToolUseOnly(t *testing.T) {
+	// toolUseTranscript turn 1 has a tool_use-only assistant entry (no text).
+	// "assistant" should exclude it entirely.
+	m, s := setupFakeTranscript(t, "detail-asst-toolonly", toolUseTranscript(t))
 	result := m.captureOutput(s, "jsonl", 2, "assistant")
 	entries := parseCaptureLines(t, result)
 
 	mustContain(t, "result", result, "I found two files")
+	mustContain(t, "result", result, "list the files")
+	mustNotContain(t, "result", result, "file1.txt")
+
 	for _, e := range entries {
 		if hasContentBlockType(e, "tool_use") {
-			t.Fatal("detail 'assistant' should not include assistant entries with only tool_use blocks")
+			t.Fatal("detail 'assistant' should not include tool_use-only assistant entries")
 		}
 		if hasContentBlockType(e, "tool_result") {
 			t.Fatal("detail 'assistant' should not include tool_result user entries")
 		}
 	}
-
-	// User prompts present, but not tool_result user entries
-	mustContain(t, "result", result, "list the files")
-	mustNotContain(t, "result", result, "file1.txt")
 }
 
 // === detail: "tools" ===

--- a/schema/protocol.json
+++ b/schema/protocol.json
@@ -43,7 +43,7 @@
     "captureDetail": {
       "enum": ["last", "assistant", "tools", "raw"],
       "default": "last",
-      "description": "What to include per turn (JSONL only, ignored for buffer). Filters both entries and content blocks. last = user prompts + final assistant text (no tool_use/tool_result). assistant = user prompts + all assistant text blocks (no tool_use/tool_result). tools = all user + assistant entries, metadata stripped. raw = everything unfiltered."
+      "description": "What to include per turn (JSONL only, ignored for buffer). last = user prompt + final assistant response, no tool calls. assistant = user prompt + all assistant text responses, no tool calls. tools = prompts + responses + tool calls/results, no metadata. raw = everything unfiltered."
     },
 
     "poolState": {

--- a/tests/integration/session_test.go
+++ b/tests/integration/session_test.go
@@ -33,14 +33,15 @@ package integration
 //   18. "new-capture: default params match turns=1 detail=last"
 //   19. "new-capture: buffer turns=1 excludes earlier turn content"
 //   20. "new-capture: buffer turns=0 contains all terminal output"
-//   21. "followup on processing errors without force"
-//   22. "followup with force on processing"
-//   23. "wait on offloaded session errors"
-//   24. "wait with no sessionId — returns first idle"
-//   25. "wait with no sessionId — errors if none busy"
-//   26. "wait with timeout"
-//   27. "input sends raw bytes and verifiable text"
-//   28. "session prefix resolution"
+//   21. "new-capture: buffer ignores detail parameter"
+//   22. "followup on processing errors without force"
+//   23. "followup with force on processing"
+//   24. "wait on offloaded session errors"
+//   25. "wait with no sessionId — returns first idle"
+//   26. "wait with no sessionId — errors if none busy"
+//   27. "wait with timeout"
+//   28. "input sends raw bytes and verifiable text"
+//   29. "session prefix resolution"
 
 import (
 	"strings"
@@ -323,6 +324,17 @@ func TestSession(t *testing.T) {
 		// Full buffer should contain output from both turns
 		assertContains(t, content, "hello world")
 		assertContains(t, content, "goodbye")
+	})
+
+	t.Run("new-capture: buffer ignores detail parameter", func(t *testing.T) {
+		// Spec: "For buffer source, detail is ignored — buffer is always raw terminal text."
+		bufDefault := pool.send(Msg{"type": "capture", "sessionId": s1, "source": "buffer", "turns": 1})
+		bufWithDetail := pool.send(Msg{"type": "capture", "sessionId": s1, "source": "buffer", "turns": 1, "detail": "raw"})
+		assertNotError(t, bufDefault)
+		assertNotError(t, bufWithDetail)
+		if strVal(bufDefault, "content") != strVal(bufWithDetail, "content") {
+			t.Fatal("buffer should return identical content regardless of detail parameter")
+		}
 	})
 
 	var s2 string


### PR DESCRIPTION
## Summary

- Replace single `format` enum (`jsonl-last`, `jsonl-short`, etc.) with three orthogonal parameters: `source` (jsonl/buffer), `turns` (numeric scope), `detail` (last/assistant/tools/raw)
- Spec stays high-level (parameter definitions + descriptions), protocol.md carries implementation details (JSONL structure, metadata stripping fields, turn boundary mechanics)
- Unit tests with realistic JSONL matching Claude Code's actual transcript format
- Integration tests for JSONL turn filtering, buffer turn boundaries, and buffer ignoring detail
- `captureOutput` stub (panics) — handlers still use old `format` API until implementation

## Test plan

- [ ] Unit tests compile and panic on stub (expected — `captureOutput` not yet implemented)
- [ ] Integration tests compile
- [ ] Spec/protocol/schema are consistent
- [ ] Old capture tests still pass (not broken by stub addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)