### PR TITLE
Fix JSONL capture: string-content prompts + legacy format field

### DIFF
--- a/internal/pool/capture.go
+++ b/internal/pool/capture.go
@@ -161,11 +161,29 @@ func (m *Manager) userPromptTexts(s *Session) []string {
 // --- Turn boundary detection ---
 
 // isUserPrompt returns true if the entry is a user prompt (has text content, not tool_result).
+// Claude Code writes user prompts with message.content as a plain string (not an array of
+// content blocks), while tool results use an array with tool_result blocks.
 func isUserPrompt(entry map[string]any) bool {
 	if typ, _ := entry["type"].(string); typ != "user" {
 		return false
 	}
-	return hasBlockType(entry, "text")
+	msg, _ := entry["message"].(map[string]any)
+	if msg == nil {
+		return false
+	}
+	switch content := msg["content"].(type) {
+	case string:
+		return true
+	case []any:
+		for _, c := range content {
+			if block, ok := c.(map[string]any); ok {
+				if t, _ := block["type"].(string); t == "text" {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // hasBlockType checks if an entry's message.content contains a block of the given type.

--- a/internal/pool/handlers.go
+++ b/internal/pool/handlers.go
@@ -548,7 +548,24 @@ func (m *Manager) handleStop(id any, req api.Msg) api.Msg {
 }
 
 // parseCaptureParams extracts source/turns/detail from a request with defaults.
+// Also supports the legacy "format" field (e.g., "jsonl-short", "buffer-full")
+// which maps to the equivalent source/turns/detail combination.
 func parseCaptureParams(req api.Msg) (source string, turns int, detail string) {
+	if format, ok := req["format"].(string); ok && format != "" {
+		switch format {
+		case "jsonl-short", "jsonl-last": // aliases — both mean last turn, last assistant response
+			return "jsonl", 1, "last"
+		case "jsonl-long":
+			return "jsonl", 1, "tools"
+		case "jsonl-full":
+			return "jsonl", 0, "raw"
+		case "buffer-last":
+			return "buffer", 1, "last"
+		case "buffer-full":
+			return "buffer", 0, "last"
+		}
+	}
+
 	source, _ = req["source"].(string)
 	if source == "" {
 		source = "jsonl"


### PR DESCRIPTION
## Summary

- **`isUserPrompt` in `capture.go`** — Claude Code writes user prompts with `message.content` as a plain string, not an array of content blocks. The function only checked for array format, causing all capture/wait operations to return empty content (no turn boundaries detected).
- **`parseCaptureParams` in `handlers.go`** — Integration tests use a legacy `format` field (e.g., `"jsonl-short"`, `"buffer-full"`). Added mapping from format strings to the new `source`/`turns`/`detail` parameters.

## Test plan

- [x] Unit tests pass (`go test ./internal/pool/`)
- [x] All integration tests pass when run individually (TestSession 27/27, TestOffload 23/23, TestSlots 14/14, TestAttach 9/9, TestSubscribe 14/14, TestPool 14/14, TestParentChild 15/15)
- [x] Haiku API throttling causes timeouts when running all suites simultaneously — not related to these changes


🤖 Generated with [Claude Code](https://claude.com/claude-code)