### PR TITLE
Fix idle signal: don't delete .pending in clear handler

### DIFF
--- a/internal/hookfiles/idle-signal.sh
+++ b/internal/hookfiles/idle-signal.sh
@@ -101,6 +101,10 @@ case "${1:-}" in
         fi
         ;;
     clear)
-        rm -f "$signal_file" "$signal_file.pending"
+        rm -f "$signal_file"
+        # NOTE: Do NOT remove $signal_file.pending here. The "stop" trigger's
+        # background verification process uses it as a coordination file. If
+        # PostToolUse fires between Stop and the verification completing, clearing
+        # .pending would prevent the idle signal from ever being written.
         ;;
 esac


### PR DESCRIPTION
## Summary

- Fix: `idle-signal.sh clear` no longer deletes `.pending` files
- Root cause: Stop hook's background verification (7s delay) uses `.pending` as coordination file, but `PostToolUse` clear was deleting it mid-verification, preventing idle signals from ever being written

## Context

All integration tests were timing out waiting for sessions to become idle. Haiku responded correctly (JSONL transcripts confirmed), but the idle signal never appeared. Traced to duplicate hook entries in `settings.json` (old direct-path + new hook-runner) causing interference, and the `clear` handler removing `.pending` files.

## Test plan

- [x] All 7 integration test suites pass (531s total):
  - TestAttach, TestOffload, TestParentChild, TestPool, TestSession, TestSlots, TestSubscribe

🤖 Generated with [Claude Code](https://claude.com/claude-code)