### PR TITLE
Don't delete .pending idle signal files from Go side

### DIFF
--- a/internal/pool/lifecycle.go
+++ b/internal/pool/lifecycle.go
@@ -694,9 +694,10 @@ func (m *Manager) startWatchers(s *Session, proc *ptyPkg.Process) {
 
 // clearIdleSignals removes stale idle signal files for a PID. Called before
 // starting watchers for a transferred process to prevent immediate false triggers.
+// Does NOT remove .pending files — those are coordination files for the Stop
+// hook's background verification process (see idle-signal.sh).
 func (m *Manager) clearIdleSignals(pid int) {
 	os.Remove(m.paths.IdleSignal(pid))
-	os.Remove(m.paths.IdleSignal(pid) + ".pending")
 }
 
 // --- Slot management ---


### PR DESCRIPTION
## Summary

Same fix as #40 but for the Go side: `clearIdleSignals()` in `lifecycle.go` was also removing `.pending` files during slot transfers.

## Test plan

- [x] `go vet ./...` passes
- [x] One-line change, same pattern as #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)