### PR TITLE
Rewrite integration tests for production-style CLI commands

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,9 +18,15 @@ Co-located with source (Go convention, `package pool`). For pure logic that does
 go test ./internal/pool/ -v
 ```
 
-### API Integration Tests (`tests/integration/`)
+### Integration Tests (`tests/integration/`)
 
-Test the daemon's behavior through the socket API with real Claude sessions. Raw JSON over Unix socket — no CLI involved. Flow-based: each file initializes a pool and walks through a sequence of operations.
+Test end-to-end behavior through the CLI with real Claude sessions. Each test runs
+`claude-pool-cli init` — the same command a real user would run. No manual daemon
+start, no hand-written config, no synthetic registry.
+
+Isolation via `CLAUDE_POOL_HOME` env var: each test gets its own directory that mirrors
+production's `~/.claude-pool/` structure. API-only features (attach, subscribe) use a
+socket connection opened after CLI init.
 
 See [tests/integration/CLAUDE.md](../tests/integration/CLAUDE.md) for philosophy, file listing, and guidelines.
 
@@ -32,10 +38,10 @@ See [tests/cli/CLAUDE.md](../tests/cli/CLAUDE.md) for philosophy and file listin
 
 ## Test Pool Config
 
-Integration tests use `--model haiku` to minimize API costs:
+Integration tests use `--model haiku` to minimize API costs, passed via `--flags` on init:
 
-```go
-config set flags "--dangerously-skip-permissions --model haiku"
+```
+claude-pool-cli init --size 2 --flags "--dangerously-skip-permissions --model haiku"
 ```
 
 ## Claude Code Constraints

--- a/tests/integration/CLAUDE.md
+++ b/tests/integration/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Philosophy
 
-These tests run against **real Claude Code sessions** through the CLI and socket API.
+These tests run against **real Claude Code sessions** through the CLI.
 No mocking — these validate end-to-end behavior with real processes. Pure logic tests
 (parsing, filtering, state transitions) belong in unit tests co-located with the
 source (`internal/*/`).
@@ -14,20 +14,37 @@ the model to write a long essay — have it run a slow bash command like `sleep 
 This keeps the session processing without burning tokens on LLM output. Only use real
 prompts when you actually need to verify the content of the response.
 
-## Two Test Modes
+## Test Setup
 
-### CLI-based tests (most tests)
+All tests use the **same pool type** (`pool`). Setup via `setupPool(t, size)` runs
+`claude-pool-cli init` — the same command a real user would run. No manual daemon
+start, no hand-written config, no synthetic registry.
+
+**Isolation via `CLAUDE_POOL_HOME`:** Each test gets its own directory that mirrors
+production's `~/.claude-pool/` structure:
+
+```
+~/.cache/claude-pool-tests/<run-id>/<TestName>/
+  .claude-pool/          ← CLAUDE_POOL_HOME (registry, pool data, socket)
+  workdir/               ← session spawn directory (--dir flag)
+```
+
+Two env vars drive isolation:
+- `CLAUDE_POOL_HOME` — redirects all pool state (registry, pool dirs)
+- `CLAUDE_POOL_DAEMON` — tells CLI where to find the daemon binary
+
+### CLI tests (most tests)
 
 Operations go through the CLI binary as subprocess calls — the same way real users
-and Claude sessions interact with pools. The test helpers (`cliPool`) build the CLI
-binary, start the daemon, and run `claude-pool-cli` commands.
+and Claude sessions interact with pools.
 
 Files: `pool_test.go`, `session_test.go`, `slots_test.go`, `offload_test.go`, `parent_child_test.go`
 
-### Socket-based tests (API-only features)
+### Socket tests (API-only features)
 
-Attach and subscribe are API-only features not exposed in the CLI. These tests use
-the socket API directly via `testPool`.
+Attach and subscribe are API-only features not exposed in the CLI. These tests
+set up the pool via CLI init (same as above), then call `pool.dial()` to open a
+raw socket connection for API-only commands.
 
 Files: `attach_test.go`, `subscribe_test.go`
 
@@ -49,21 +66,21 @@ test prompts must use relative subdirectories.
 
 ## Structure
 
-| File | Pool size | Mode | What it covers |
-|------|-----------|------|----------------|
-| `pool_test.go` | 2 | CLI | Init, ping, config, resize, health, destroy, re-init with restore |
-| `session_test.go` | 3 | CLI | Start, wait, capture, followup, info, set (metadata), stop, --block, prefix resolution |
-| `slots_test.go` | 2 | CLI | Queue, set priority, set pinned, eviction order, LRU |
-| `offload_test.go` | 2 | CLI | Eviction→offload, capture offloaded, followup restores, process death, archive/unarchive lifecycle |
-| `parent_child_test.go` | 3 | CLI | --parent flag, env auto-detection, --parent none, ls filtering, verbosity, recursive archive |
-| `attach_test.go` | 2 | Socket | Attach pipe, pendingInput, keystroke/submit, eviction closes pipe, re-attach |
-| `subscribe_test.go` | 2 | Socket | Event stream, filters, re-subscribe, updated events |
+| File | Pool size | What it covers |
+|------|-----------|----------------|
+| `pool_test.go` | 2 | Init, ping, config, resize, health, destroy, re-init with restore |
+| `session_test.go` | 3 | Start, wait, capture, followup, info, set (metadata), stop, --block, prefix resolution |
+| `slots_test.go` | 2 | Queue, set priority, set pinned, eviction order, LRU |
+| `offload_test.go` | 2 | Eviction→offload, capture offloaded, followup restores, process death, archive/unarchive lifecycle |
+| `parent_child_test.go` | 3 | --parent flag, env auto-detection, --parent none, ls filtering, verbosity, recursive archive |
+| `attach_test.go` | 2 | Attach pipe, pendingInput, keystroke/submit, eviction closes pipe, re-attach |
+| `subscribe_test.go` | 2 | Event stream, filters, re-subscribe, updated events |
 
 Shared infrastructure:
 
 | File | Purpose |
 |------|---------|
-| `helpers_test.go` | Both pool types (CLI + socket), assertion helpers, waiting helpers |
+| `helpers_test.go` | Pool struct (CLI + socket), setup helpers, assertion helpers, waiting helpers |
 | `../testutil/testutil.go` | TestMain utilities: find repo root, build binary, setup run dir |
 
 ## Running
@@ -85,8 +102,9 @@ Every command and its flags should be visible in the test.
 
 ### Socket tests
 
-Use `pool.send(Msg{...})` directly for all protocol commands. Every request and response
-should be visible — no hidden abstractions.
+Use `sc.send(Msg{...})` directly for API-only commands. CLI commands still go through
+`pool.run(...)` / `pool.runJSON(...)`. Every request should be visible — no hidden
+abstractions.
 
 ### Comments
 

--- a/tests/integration/attach_test.go
+++ b/tests/integration/attach_test.go
@@ -9,8 +9,8 @@ package integration
 // while attached, and pipe lifecycle (eviction closes pipe, re-attach
 // after restore).
 //
-// Attach is an API-only feature (not exposed in CLI), so this test uses
-// the socket API directly.
+// Attach is an API-only feature (not exposed in CLI). The pool is created
+// via CLI init, then pool.dial() opens a socket connection for API commands.
 //
 // Flow:
 //
@@ -34,7 +34,8 @@ import (
 )
 
 func TestAttach(t *testing.T) {
-	pool := setupPool(t, 2)
+	p := setupPool(t, 2)
+	sc := p.dial()
 
 	var s1 string
 	var attachConn net.Conn
@@ -46,18 +47,17 @@ func TestAttach(t *testing.T) {
 	})
 
 	t.Run("start and pin session", func(t *testing.T) {
-		resp := pool.send(Msg{"type": "start", "prompt": "respond with exactly: attach-init"})
-		assertNotError(t, resp)
+		resp := p.runJSON("start", "--prompt", "respond with exactly: attach-init")
 		s1 = strVal(resp, "sessionId")
-		pool.awaitStatus(s1, "idle", 60*time.Second)
+		p.waitForStatus(s1, "idle", 60*time.Second)
 
 		// Pin to prevent eviction during attach tests
-		pinResp := pool.send(Msg{"type": "set", "sessionId": s1, "pinned": 300})
+		pinResp := sc.send(Msg{"type": "set", "sessionId": s1, "pinned": 300})
 		assertNotError(t, pinResp)
 	})
 
 	t.Run("attach to idle session", func(t *testing.T) {
-		resp := pool.send(Msg{"type": "attach", "sessionId": s1})
+		resp := sc.send(Msg{"type": "attach", "sessionId": s1})
 		assertNotError(t, resp)
 		assertType(t, resp, "attached")
 
@@ -97,14 +97,14 @@ func TestAttach(t *testing.T) {
 		if _, err := attachConn.Write([]byte("hello")); err != nil {
 			t.Fatalf("write to attach socket: %v", err)
 		}
-		pool.awaitPendingInputSet(s1, 10*time.Second)
+		p.waitForPendingInput(s1, func(v string) bool { return v != "" }, 10*time.Second)
 	})
 
 	t.Run("clearing input clears pendingInput", func(t *testing.T) {
 		if _, err := attachConn.Write([]byte("\x15")); err != nil {
 			t.Fatalf("write Ctrl-U: %v", err)
 		}
-		pool.awaitPendingInputClear(s1, 10*time.Second)
+		p.waitForPendingInput(s1, func(v string) bool { return v == "" }, 10*time.Second)
 	})
 
 	t.Run("submit via attach triggers processing and completes", func(t *testing.T) {
@@ -112,10 +112,10 @@ func TestAttach(t *testing.T) {
 			t.Fatalf("write prompt: %v", err)
 		}
 
-		pool.awaitStatus(s1, "processing", 15*time.Second)
-		pool.awaitStatus(s1, "idle", 30*time.Second)
+		p.waitForStatus(s1, "processing", 15*time.Second)
+		p.waitForStatus(s1, "idle", 30*time.Second)
 
-		resp := pool.send(Msg{"type": "capture", "sessionId": s1, "source": "jsonl", "detail": "last"})
+		resp := sc.send(Msg{"type": "capture", "sessionId": s1, "source": "jsonl", "detail": "last"})
 		assertNotError(t, resp)
 		assertContains(t, strVal(resp, "content"), "attach-test-output")
 	})
@@ -123,13 +123,13 @@ func TestAttach(t *testing.T) {
 	t.Run("followup via API while attached", func(t *testing.T) {
 		drainAttach(attachConn)
 
-		resp := pool.send(Msg{
+		resp := sc.send(Msg{
 			"type": "followup", "sessionId": s1,
 			"prompt": "respond with exactly: followup-while-attached",
 		})
 		assertNotError(t, resp)
 
-		pool.awaitStatus(s1, "processing", 15*time.Second)
+		p.waitForStatus(s1, "processing", 15*time.Second)
 
 		buf := make([]byte, 8192)
 		attachConn.SetReadDeadline(time.Now().Add(30 * time.Second))
@@ -141,28 +141,28 @@ func TestAttach(t *testing.T) {
 			t.Fatal("expected terminal output from followup on attach pipe")
 		}
 
-		pool.awaitStatus(s1, "idle", 30*time.Second)
+		p.waitForStatus(s1, "idle", 30*time.Second)
 
-		captureResp := pool.send(Msg{"type": "capture", "sessionId": s1, "source": "jsonl", "detail": "last"})
+		captureResp := sc.send(Msg{"type": "capture", "sessionId": s1, "source": "jsonl", "detail": "last"})
 		assertNotError(t, captureResp)
 		assertContains(t, strVal(captureResp, "content"), "followup-while-attached")
 	})
 
 	t.Run("eviction closes attach pipe", func(t *testing.T) {
 		// Unpin s1 so it can be evicted
-		pool.send(Msg{"type": "set", "sessionId": s1, "pinned": false})
+		sc.send(Msg{"type": "set", "sessionId": s1, "pinned": false})
 
 		// Start a new session to use the other fresh slot
-		r := pool.send(Msg{"type": "start", "prompt": "respond with exactly: filler"})
+		r := sc.send(Msg{"type": "start", "prompt": "respond with exactly: filler"})
 		assertNotError(t, r)
 		sNew := strVal(r, "sessionId")
-		pool.awaitStatus(sNew, "idle", 60*time.Second)
+		p.waitForStatus(sNew, "idle", 60*time.Second)
 
 		// Now both slots are full (s1 + sNew). Start another → s1 (LRU) gets evicted.
-		r2 := pool.send(Msg{"type": "start", "prompt": "respond with exactly: evict-trigger"})
+		r2 := sc.send(Msg{"type": "start", "prompt": "respond with exactly: evict-trigger"})
 		assertNotError(t, r2)
 
-		pool.awaitStatus(s1, "offloaded", 15*time.Second)
+		p.waitForStatus(s1, "offloaded", 15*time.Second)
 
 		// Drain residual PTY output before expecting EOF
 		buf := make([]byte, 4096)
@@ -179,20 +179,18 @@ func TestAttach(t *testing.T) {
 	})
 
 	t.Run("attach fails on offloaded session", func(t *testing.T) {
-		resp := pool.send(Msg{"type": "attach", "sessionId": s1})
+		resp := sc.send(Msg{"type": "attach", "sessionId": s1})
 		assertError(t, resp)
 	})
 
 	t.Run("restore and re-attach", func(t *testing.T) {
-		// Restore s1 via followup (triggers load from offloaded state)
-		resp := pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "respond with exactly: restored"})
+		resp := sc.send(Msg{"type": "followup", "sessionId": s1, "prompt": "respond with exactly: restored"})
 		assertNotError(t, resp)
-		pool.awaitStatus(s1, "idle", 60*time.Second)
+		p.waitForStatus(s1, "idle", 60*time.Second)
 
-		// Pin to keep it loaded
-		pool.send(Msg{"type": "set", "sessionId": s1, "pinned": 300})
+		sc.send(Msg{"type": "set", "sessionId": s1, "pinned": 300})
 
-		attachResp := pool.send(Msg{"type": "attach", "sessionId": s1})
+		attachResp := sc.send(Msg{"type": "attach", "sessionId": s1})
 		assertNotError(t, attachResp)
 		assertType(t, attachResp, "attached")
 

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -2,17 +2,24 @@ package integration
 
 // helpers_test.go — Shared test infrastructure
 //
-// Two pool types for two kinds of tests:
+// Single pool type for all tests:
 //
-//   cliPool — For tests that exercise the CLI (pool, session, slots, offload, parent_child).
-//     Setup: build daemon + CLI binaries, run `init` via CLI, which starts the daemon.
+//   pool — All operations go through CLI commands, just like production.
+//     Setup: build daemon + CLI binaries, run `init` via CLI (which starts the daemon).
 //     Operations: run CLI commands as subprocesses, parse JSON output.
 //     Waiting: poll `info --json` for status, use `wait` CLI command for idle.
 //
-//   testPool — For tests that need raw socket access (attach, subscribe).
-//     Setup: start daemon directly, connect socket, send init.
-//     Operations: send JSON messages on socket, read responses.
-//     Kept because attach and subscribe are API-only features not exposed in the CLI.
+//   For API-only features (attach, subscribe), pool.dial() opens a raw socket
+//   connection to the daemon for direct JSON messaging.
+//
+// Isolation:
+//
+//   Each test gets its own directory under ~/.cache/claude-pool-tests/:
+//     <testDir>/.claude-pool/   ← CLAUDE_POOL_HOME (registry, pool data)
+//     <testDir>/workdir/        ← session spawn directory
+//
+//   CLAUDE_POOL_HOME mirrors the production ~/.claude-pool/ structure.
+//   CLAUDE_POOL_DAEMON tells the CLI where to find the daemon binary.
 
 import (
 	"bufio"
@@ -23,7 +30,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -161,16 +167,14 @@ var (
 )
 
 // ====================================================================
-// CLI-based pool (for pool, session, slots, offload, parent_child tests)
+// Pool — all operations go through CLI commands
 // ====================================================================
 
-type cliPool struct {
-	t            *testing.T
-	poolDir      string
-	poolName     string
-	registryPath string
-	cliBin       string
-	daemonBin    string
+type pool struct {
+	t       *testing.T
+	name    string
+	homeDir string // CLAUDE_POOL_HOME
+	workDir string // session spawn directory
 }
 
 type cmdResult struct {
@@ -179,213 +183,70 @@ type cmdResult struct {
 	ExitCode int
 }
 
-// setupCLIPool creates a pool via CLI init: starts the daemon, initializes
-// the pool, and returns a cliPool ready for CLI commands.
-func setupCLIPool(t *testing.T, size int) *cliPool {
+// newPool creates the directory structure but does NOT init.
+// For tests that need to control init timing (e.g., TestPool).
+func newPool(t *testing.T) *pool {
 	t.Helper()
 
-	poolDir := filepath.Join(runDir, t.Name())
-	if err := os.MkdirAll(poolDir, 0755); err != nil {
-		t.Fatalf("failed to create pool dir: %v", err)
+	testDir := filepath.Join(runDir, t.Name())
+	cpHome := filepath.Join(testDir, ".claude-pool")
+	workDir := filepath.Join(testDir, "workdir")
+
+	if err := os.MkdirAll(cpHome, 0755); err != nil {
+		t.Fatalf("failed to create .claude-pool dir: %v", err)
+	}
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatalf("failed to create workdir: %v", err)
 	}
 
-	poolName := "test"
-
-	// Write registry so CLI can resolve pool name → socket
-	registryDir := filepath.Join(poolDir, "registry")
-	if err := os.MkdirAll(registryDir, 0755); err != nil {
-		t.Fatalf("failed to create registry dir: %v", err)
-	}
-	socketPath := filepath.Join(poolDir, "api.sock")
-	registry := Msg{poolName: Msg{"socket": socketPath}}
-	registryBytes, _ := json.Marshal(registry)
-	registryPath := filepath.Join(registryDir, "pools.json")
-	if err := os.WriteFile(registryPath, registryBytes, 0644); err != nil {
-		t.Fatalf("failed to write registry: %v", err)
+	p := &pool{
+		t:       t,
+		name:    "test",
+		homeDir: cpHome,
+		workDir: workDir,
 	}
 
-	// Write pool config
-	configPath := filepath.Join(poolDir, "config.json")
-	config := Msg{
-		"flags": "--dangerously-skip-permissions --model haiku",
-		"size":  size,
-	}
-	configBytes, _ := json.Marshal(config)
-	if err := os.WriteFile(configPath, configBytes, 0644); err != nil {
-		t.Fatalf("failed to write config: %v", err)
+	t.Cleanup(func() {
+		p.run("destroy", "--confirm")
+	})
+
+	return p
+}
+
+// setupPool creates a pool via CLI init and waits for all slots to become idle.
+func setupPool(t *testing.T, size int) *pool {
+	t.Helper()
+
+	p := newPool(t)
+
+	result := p.run("init", "--size", fmt.Sprintf("%d", size),
+		"--dir", p.workDir,
+		"--flags", "--dangerously-skip-permissions --model haiku")
+	if result.ExitCode != 0 {
+		t.Fatalf("init failed (exit %d): %s", result.ExitCode, result.Stderr)
 	}
 
-	p := &cliPool{
-		t:            t,
-		poolDir:      poolDir,
-		poolName:     poolName,
-		registryPath: registryPath,
-		cliBin:       cliBinPath,
-		daemonBin:    daemonBinPath,
-	}
-
-	// Start daemon process
-	daemon := exec.Command(daemonBinPath, "--pool-dir", poolDir)
-	daemon.Stdout = os.Stdout
-	daemon.Stderr = os.Stderr
-	if err := daemon.Start(); err != nil {
-		t.Fatalf("failed to start daemon: %v", err)
-	}
-
-	// Wait for socket to appear
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(socketPath); err == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if _, err := os.Stat(socketPath); err != nil {
-		daemon.Process.Kill()
-		t.Fatalf("daemon socket never appeared at %s", socketPath)
-	}
-
-	// Init via CLI
-	initResult := p.run("init", "--size", fmt.Sprintf("%d", size))
-	if initResult.ExitCode != 0 {
-		daemon.Process.Kill()
-		t.Fatalf("init failed: %s", initResult.Stderr)
-	}
-
-	// Wait for all initial sessions to become idle
 	p.waitForIdleCount(size, 90*time.Second)
-
-	t.Cleanup(func() {
-		// Best-effort destroy via CLI
-		p.run("destroy", "--confirm")
-		daemon.Process.Kill()
-		daemon.Wait()
-	})
-
 	return p
-}
-
-// setupCLIDaemon starts the daemon but does NOT init. For tests that need
-// to control init timing (e.g., testing ping/config before init).
-func setupCLIDaemon(t *testing.T, size int) *cliPool {
-	t.Helper()
-
-	poolDir := filepath.Join(runDir, t.Name())
-	if err := os.MkdirAll(poolDir, 0755); err != nil {
-		t.Fatalf("failed to create pool dir: %v", err)
-	}
-
-	poolName := "test"
-	socketPath := filepath.Join(poolDir, "api.sock")
-
-	// Write registry
-	registryDir := filepath.Join(poolDir, "registry")
-	if err := os.MkdirAll(registryDir, 0755); err != nil {
-		t.Fatalf("failed to create registry dir: %v", err)
-	}
-	registry := Msg{poolName: Msg{"socket": socketPath}}
-	registryBytes, _ := json.Marshal(registry)
-	registryPath := filepath.Join(registryDir, "pools.json")
-	if err := os.WriteFile(registryPath, registryBytes, 0644); err != nil {
-		t.Fatalf("failed to write registry: %v", err)
-	}
-
-	// Write pool config
-	configPath := filepath.Join(poolDir, "config.json")
-	config := Msg{
-		"flags": "--dangerously-skip-permissions --model haiku",
-		"size":  size,
-	}
-	configBytes, _ := json.Marshal(config)
-	if err := os.WriteFile(configPath, configBytes, 0644); err != nil {
-		t.Fatalf("failed to write config: %v", err)
-	}
-
-	p := &cliPool{
-		t:            t,
-		poolDir:      poolDir,
-		poolName:     poolName,
-		registryPath: registryPath,
-		cliBin:       cliBinPath,
-		daemonBin:    daemonBinPath,
-	}
-
-	p.startDaemon()
-
-	t.Cleanup(func() {
-		p.run("destroy", "--confirm")
-		p.killDaemon()
-	})
-
-	return p
-}
-
-// startDaemon starts (or restarts) the daemon process and waits for the socket.
-func (p *cliPool) startDaemon() {
-	p.t.Helper()
-	socketPath := filepath.Join(p.poolDir, "api.sock")
-
-	daemon := exec.Command(p.daemonBin, "--pool-dir", p.poolDir)
-	daemon.Stdout = os.Stdout
-	daemon.Stderr = os.Stderr
-	if err := daemon.Start(); err != nil {
-		p.t.Fatalf("failed to start daemon: %v", err)
-	}
-
-	// Store for cleanup
-	p.setDaemon(daemon)
-
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(socketPath); err == nil {
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	daemon.Process.Kill()
-	p.t.Fatalf("daemon socket never appeared at %s", socketPath)
-}
-
-// daemon tracking — stored separately since cliPool is value-oriented
-var daemonProcs sync.Map // poolDir → *exec.Cmd
-
-func (p *cliPool) setDaemon(cmd *exec.Cmd) {
-	daemonProcs.Store(p.poolDir, cmd)
-}
-
-func (p *cliPool) killDaemon() {
-	if v, ok := daemonProcs.Load(p.poolDir); ok {
-		cmd := v.(*exec.Cmd)
-		cmd.Process.Kill()
-		cmd.Wait()
-		daemonProcs.Delete(p.poolDir)
-	}
-}
-
-// awaitSocketGone polls until the socket file disappears.
-func (p *cliPool) awaitSocketGone(timeout time.Duration) {
-	p.t.Helper()
-	socketPath := filepath.Join(p.poolDir, "api.sock")
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(socketPath); os.IsNotExist(err) {
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	p.t.Fatalf("socket still exists after %v", timeout)
 }
 
 // --- CLI execution ---
 
+func (p *pool) cliEnv() []string {
+	return append(os.Environ(),
+		"CLAUDE_POOL_HOME="+p.homeDir,
+		"CLAUDE_POOL_DAEMON="+daemonBinPath,
+	)
+}
+
 // run executes a CLI command with --pool prepended.
-func (p *cliPool) run(args ...string) cmdResult {
+func (p *pool) run(args ...string) cmdResult {
 	p.t.Helper()
 	return p.execCLI(nil, args...)
 }
 
 // runJSON executes a CLI command with --json and parses stdout.
-func (p *cliPool) runJSON(args ...string) Msg {
+func (p *pool) runJSON(args ...string) Msg {
 	p.t.Helper()
 	result := p.run(append(args, "--json")...)
 	if result.ExitCode != 0 {
@@ -399,7 +260,7 @@ func (p *cliPool) runJSON(args ...string) Msg {
 }
 
 // runInSession executes a CLI command with CLAUDE_POOL_SESSION_ID set.
-func (p *cliPool) runInSession(sessionID string, args ...string) cmdResult {
+func (p *pool) runInSession(sessionID string, args ...string) cmdResult {
 	p.t.Helper()
 	return p.execCLI([]string{
 		fmt.Sprintf("CLAUDE_POOL_SESSION_ID=%s", sessionID),
@@ -407,7 +268,7 @@ func (p *cliPool) runInSession(sessionID string, args ...string) cmdResult {
 }
 
 // runInSessionJSON is runInSession + JSON parsing.
-func (p *cliPool) runInSessionJSON(sessionID string, args ...string) Msg {
+func (p *pool) runInSessionJSON(sessionID string, args ...string) Msg {
 	p.t.Helper()
 	result := p.runInSession(sessionID, append(args, "--json")...)
 	if result.ExitCode != 0 {
@@ -420,14 +281,11 @@ func (p *cliPool) runInSessionJSON(sessionID string, args ...string) Msg {
 	return msg
 }
 
-func (p *cliPool) execCLI(extraEnv []string, args ...string) cmdResult {
+func (p *pool) execCLI(extraEnv []string, args ...string) cmdResult {
 	p.t.Helper()
-	fullArgs := append([]string{"--pool", p.poolName}, args...)
-	cmd := exec.Command(p.cliBin, fullArgs...)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("CLAUDE_POOL_REGISTRY=%s", p.registryPath),
-	)
-	cmd.Env = append(cmd.Env, extraEnv...)
+	fullArgs := append([]string{"--pool", p.name}, args...)
+	cmd := exec.Command(cliBinPath, fullArgs...)
+	cmd.Env = append(p.cliEnv(), extraEnv...)
 
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
@@ -453,7 +311,7 @@ func (p *cliPool) execCLI(extraEnv []string, args ...string) cmdResult {
 // --- Waiting helpers (CLI-based) ---
 
 // waitForStatus polls `info --json` until the session reaches the target status.
-func (p *cliPool) waitForStatus(sessionID, target string, timeout time.Duration) SessionInfo {
+func (p *pool) waitForStatus(sessionID, target string, timeout time.Duration) SessionInfo {
 	p.t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -471,14 +329,13 @@ func (p *cliPool) waitForStatus(sessionID, target string, timeout time.Duration)
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	// Final check for error message
 	result := p.run("info", "--session", sessionID, "--json")
 	p.t.Fatalf("waitForStatus(%s, %q): timed out after %v\nlast info: %s", sessionID, target, timeout, result.Stdout)
 	return SessionInfo{}
 }
 
 // waitForIdle uses the CLI wait command.
-func (p *cliPool) waitForIdle(sessionID string, timeout time.Duration) Msg {
+func (p *pool) waitForIdle(sessionID string, timeout time.Duration) Msg {
 	p.t.Helper()
 	result := p.run("wait", "--session", sessionID, "--timeout", fmt.Sprintf("%d", timeout.Milliseconds()), "--json")
 	if result.ExitCode != 0 {
@@ -492,7 +349,7 @@ func (p *cliPool) waitForIdle(sessionID string, timeout time.Duration) Msg {
 }
 
 // waitForIdleCount polls health until at least n sessions are idle.
-func (p *cliPool) waitForIdleCount(n int, timeout time.Duration) {
+func (p *pool) waitForIdleCount(n int, timeout time.Duration) {
 	p.t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -515,7 +372,7 @@ func (p *cliPool) waitForIdleCount(n int, timeout time.Duration) {
 }
 
 // waitForPoolSize polls health until the pool reaches the target slot count.
-func (p *cliPool) waitForPoolSize(target int, timeout time.Duration) {
+func (p *pool) waitForPoolSize(target int, timeout time.Duration) {
 	p.t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -535,8 +392,41 @@ func (p *cliPool) waitForPoolSize(target int, timeout time.Duration) {
 	p.t.Fatalf("waitForPoolSize(%d): timed out after %v", target, timeout)
 }
 
+// waitForPendingInput polls info until pendingInput matches.
+func (p *pool) waitForPendingInput(sessionID string, match func(string) bool, timeout time.Duration) string {
+	p.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		info := p.getSessionInfo(sessionID)
+		if match(info.PendingInput) {
+			return info.PendingInput
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	info := p.getSessionInfo(sessionID)
+	p.t.Fatalf("waitForPendingInput(%s): timed out after %v, pendingInput was %q",
+		sessionID, timeout, info.PendingInput)
+	return ""
+}
+
+// awaitSocketGone polls until the pool's socket file disappears.
+func (p *pool) awaitSocketGone(timeout time.Duration) {
+	p.t.Helper()
+	socketPath := filepath.Join(p.homeDir, p.name, "api.sock")
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(socketPath); os.IsNotExist(err) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	p.t.Fatalf("socket still exists after %v", timeout)
+}
+
+// --- Convenience helpers ---
+
 // getSessionInfo runs info --json and returns parsed session.
-func (p *cliPool) getSessionInfo(sessionID string) SessionInfo {
+func (p *pool) getSessionInfo(sessionID string) SessionInfo {
 	p.t.Helper()
 	resp := p.runJSON("info", "--session", sessionID)
 	session, ok := resp["session"].(map[string]any)
@@ -547,7 +437,7 @@ func (p *cliPool) getSessionInfo(sessionID string) SessionInfo {
 }
 
 // getHealth runs health --json and returns the health object.
-func (p *cliPool) getHealth() Msg {
+func (p *pool) getHealth() Msg {
 	p.t.Helper()
 	resp := p.runJSON("health")
 	health, ok := resp["health"].(map[string]any)
@@ -558,7 +448,7 @@ func (p *cliPool) getHealth() Msg {
 }
 
 // listSessions runs ls --json with optional args and returns parsed sessions.
-func (p *cliPool) listSessions(args ...string) []SessionInfo {
+func (p *pool) listSessions(args ...string) []SessionInfo {
 	p.t.Helper()
 	fullArgs := append([]string{"ls"}, args...)
 	resp := p.runJSON(fullArgs...)
@@ -566,317 +456,90 @@ func (p *cliPool) listSessions(args ...string) []SessionInfo {
 }
 
 // ====================================================================
-// Socket-based pool (for attach and subscribe tests)
+// Socket connection — for API-only features (attach, subscribe)
 // ====================================================================
 
-type testPool struct {
+type socketConn struct {
 	t          *testing.T
-	dir        string
-	binPath    string
-	socketPath string
 	conn       net.Conn
 	scanner    *bufio.Scanner
-	daemon     *exec.Cmd
+	socketPath string
 	nextID     atomic.Int64
 }
 
-// setupPool builds the daemon, starts it, calls init, and returns a connected testPool.
-func setupPool(t *testing.T, size int) *testPool {
-	t.Helper()
-	p := setupDaemon(t, size)
-
-	resp := p.send(Msg{"type": "init", "size": size})
-	if resp["type"] == "error" {
-		t.Fatalf("init failed: %v", resp["error"])
+// dial opens a socket connection to the pool's API socket.
+func (p *pool) dial() *socketConn {
+	p.t.Helper()
+	socketPath := filepath.Join(p.homeDir, p.name, "api.sock")
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		p.t.Fatalf("failed to connect to socket %s: %v", socketPath, err)
 	}
-
-	return p
-}
-
-// setupDaemon starts a daemon but does NOT call init.
-func setupDaemon(t *testing.T, size int) *testPool {
-	t.Helper()
-
-	poolDir := filepath.Join(runDir, t.Name())
-	if err := os.MkdirAll(poolDir, 0755); err != nil {
-		t.Fatalf("failed to create pool dir: %v", err)
-	}
-	socketPath := filepath.Join(poolDir, "api.sock")
-
-	configPath := filepath.Join(poolDir, "config.json")
-	config := Msg{
-		"flags": "--dangerously-skip-permissions --model haiku",
-		"size":  size,
-	}
-	configBytes, _ := json.Marshal(config)
-	if err := os.WriteFile(configPath, configBytes, 0644); err != nil {
-		t.Fatalf("failed to write config: %v", err)
-	}
-
-	p := &testPool{
-		t:          t,
-		dir:        poolDir,
-		binPath:    daemonBinPath,
+	sc := &socketConn{
+		t:          p.t,
+		conn:       conn,
+		scanner:    bufio.NewScanner(conn),
 		socketPath: socketPath,
 	}
-
-	p.startDaemon()
-
-	t.Cleanup(func() {
-		p.send(Msg{"type": "destroy", "confirm": true})
-		p.conn.Close()
-		if p.daemon != nil && p.daemon.Process != nil {
-			p.daemon.Process.Kill()
-		}
-	})
-
-	return p
+	p.t.Cleanup(func() { conn.Close() })
+	return sc
 }
 
-func (p *testPool) startDaemon() {
-	p.t.Helper()
-
-	daemon := exec.Command(p.binPath, "--pool-dir", p.dir)
-	daemon.Stdout = os.Stdout
-	daemon.Stderr = os.Stderr
-	if err := daemon.Start(); err != nil {
-		p.t.Fatalf("failed to start daemon: %v", err)
-	}
-	p.daemon = daemon
-
-	daemonDied := make(chan struct{})
-	go func() {
-		daemon.Wait()
-		close(daemonDied)
-	}()
-
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(p.socketPath); err == nil {
-			break
-		}
-		select {
-		case <-daemonDied:
-			p.t.Fatalf("daemon exited before socket appeared")
-		default:
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if _, err := os.Stat(p.socketPath); err != nil {
-		daemon.Process.Kill()
-		p.t.Fatalf("daemon socket never appeared at %s", p.socketPath)
-	}
-
-	conn, err := net.Dial("unix", p.socketPath)
-	if err != nil {
-		daemon.Process.Kill()
-		p.t.Fatalf("failed to connect to daemon socket: %v", err)
-	}
-	p.conn = conn
-	p.scanner = bufio.NewScanner(conn)
+func (sc *socketConn) send(msg Msg) Msg {
+	sc.t.Helper()
+	msg["id"] = int(sc.nextID.Add(1))
+	return sc.doSend(sc.conn, sc.scanner, msg, 10*time.Second)
 }
 
-func (p *testPool) send(msg Msg) Msg {
-	p.t.Helper()
-	msg["id"] = int(p.nextID.Add(1))
-	return p.doSend(p.conn, p.scanner, msg, 10*time.Second)
+func (sc *socketConn) sendLong(msg Msg, readTimeout time.Duration) Msg {
+	sc.t.Helper()
+	msg["id"] = int(sc.nextID.Add(1))
+	return sc.doSend(sc.conn, sc.scanner, msg, readTimeout)
 }
 
-func (p *testPool) sendLong(msg Msg, readTimeout time.Duration) Msg {
-	p.t.Helper()
-	msg["id"] = int(p.nextID.Add(1))
-	return p.doSend(p.conn, p.scanner, msg, readTimeout)
-}
-
-func (p *testPool) doSend(conn net.Conn, scanner *bufio.Scanner, msg Msg, readTimeout time.Duration) Msg {
-	p.t.Helper()
+func (sc *socketConn) doSend(conn net.Conn, scanner *bufio.Scanner, msg Msg, readTimeout time.Duration) Msg {
+	sc.t.Helper()
 
 	data, err := json.Marshal(msg)
 	if err != nil {
-		p.t.Fatalf("marshal: %v", err)
+		sc.t.Fatalf("marshal: %v", err)
 	}
 	data = append(data, '\n')
 
 	conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 	if _, err := conn.Write(data); err != nil {
-		p.t.Fatalf("write: %v", err)
+		sc.t.Fatalf("write: %v", err)
 	}
 
 	conn.SetReadDeadline(time.Now().Add(readTimeout))
 	if !scanner.Scan() {
 		if err := scanner.Err(); err != nil {
-			p.t.Fatalf("read: %v", err)
+			sc.t.Fatalf("read: %v", err)
 		}
-		p.t.Fatal("connection closed while reading response")
+		sc.t.Fatal("connection closed while reading response")
 	}
 
 	var resp Msg
 	if err := json.Unmarshal(scanner.Bytes(), &resp); err != nil {
-		p.t.Fatalf("unmarshal response: %v\nraw: %s", err, scanner.Text())
+		sc.t.Fatalf("unmarshal response: %v\nraw: %s", err, scanner.Text())
 	}
 	return resp
 }
 
-func (p *testPool) newConn() (net.Conn, *bufio.Scanner) {
-	p.t.Helper()
-	conn, err := net.Dial("unix", p.socketPath)
+func (sc *socketConn) newConn() (net.Conn, *bufio.Scanner) {
+	sc.t.Helper()
+	conn, err := net.Dial("unix", sc.socketPath)
 	if err != nil {
-		p.t.Fatalf("failed to open new connection: %v", err)
+		sc.t.Fatalf("failed to open new connection: %v", err)
 	}
-	p.t.Cleanup(func() { conn.Close() })
+	sc.t.Cleanup(func() { conn.Close() })
 	return conn, bufio.NewScanner(conn)
 }
 
-func (p *testPool) sendOn(conn net.Conn, scanner *bufio.Scanner, msg Msg) Msg {
-	p.t.Helper()
-	msg["id"] = int(p.nextID.Add(1))
-	return p.doSend(conn, scanner, msg, 10*time.Second)
-}
-
-// awaitStatus uses subscribe to wait for a session to reach a target status.
-func (p *testPool) awaitStatus(sessionID, target string, timeout time.Duration) SessionInfo {
-	p.t.Helper()
-
-	sub := p.subscribe(Msg{
-		"sessions": []string{sessionID},
-		"events":   []string{"status"},
-		"statuses": []string{target},
-	})
-	defer sub.close()
-
-	resp := p.send(Msg{"type": "info", "sessionId": sessionID})
-	if resp["type"] == "error" {
-		p.t.Fatalf("awaitStatus info failed: %v", resp["error"])
-	}
-	info := parseSession(p.t, resp["session"])
-	if info.Status == target {
-		return info
-	}
-
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		ev, ok := sub.nextWithin(time.Until(deadline))
-		if !ok {
-			break
-		}
-		if strVal(ev, "sessionId") == sessionID && strVal(ev, "status") == target {
-			resp = p.send(Msg{"type": "info", "sessionId": sessionID})
-			if resp["type"] == "error" {
-				p.t.Fatalf("awaitStatus info failed: %v", resp["error"])
-			}
-			return parseSession(p.t, resp["session"])
-		}
-	}
-
-	resp = p.send(Msg{"type": "info", "sessionId": sessionID})
-	info = parseSession(p.t, resp["session"])
-	p.t.Fatalf("awaitStatus(%s, %q): timed out after %v, last status was %q",
-		sessionID, target, timeout, info.Status)
-	return SessionInfo{}
-}
-
-func (p *testPool) awaitIdleCount(n int, timeout time.Duration) {
-	p.t.Helper()
-
-	sub := p.subscribe(Msg{"events": []string{"status"}, "statuses": []string{"idle"}})
-	defer sub.close()
-
-	resp := p.send(Msg{"type": "health"})
-	health, _ := resp["health"].(map[string]any)
-	counts, _ := health["counts"].(map[string]any)
-	if int(numVal(counts, "idle")) >= n {
-		return
-	}
-
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		_, ok := sub.nextWithin(time.Until(deadline))
-		if !ok {
-			break
-		}
-		resp = p.send(Msg{"type": "health"})
-		health, _ = resp["health"].(map[string]any)
-		counts, _ = health["counts"].(map[string]any)
-		if int(numVal(counts, "idle")) >= n {
-			return
-		}
-	}
-	p.t.Fatalf("awaitIdleCount(%d): timed out after %v", n, timeout)
-}
-
-func (p *testPool) awaitPoolSize(target int, timeout time.Duration) {
-	p.t.Helper()
-
-	sub := p.subscribe(Msg{"events": []string{"pool"}})
-	defer sub.close()
-
-	resp := p.send(Msg{"type": "health"})
-	health, _ := resp["health"].(map[string]any)
-	if int(numVal(health, "size")) == target {
-		return
-	}
-
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		_, ok := sub.nextWithin(time.Until(deadline))
-		if !ok {
-			break
-		}
-		resp = p.send(Msg{"type": "health"})
-		health, _ = resp["health"].(map[string]any)
-		if int(numVal(health, "size")) == target {
-			return
-		}
-	}
-	p.t.Fatalf("awaitPoolSize(%d): timed out after %v", target, timeout)
-}
-
-func (p *testPool) awaitPendingInputSet(sessionID string, timeout time.Duration) string {
-	p.t.Helper()
-	return p.awaitPendingInput(sessionID, func(v string) bool { return v != "" }, timeout)
-}
-
-func (p *testPool) awaitPendingInputClear(sessionID string, timeout time.Duration) {
-	p.t.Helper()
-	p.awaitPendingInput(sessionID, func(v string) bool { return v == "" }, timeout)
-}
-
-func (p *testPool) awaitPendingInput(sessionID string, match func(string) bool, timeout time.Duration) string {
-	p.t.Helper()
-
-	sub := p.subscribe(Msg{
-		"sessions": []string{sessionID},
-		"events":   []string{"updated"},
-		"fields":   []string{"pendingInput"},
-	})
-	defer sub.close()
-
-	resp := p.send(Msg{"type": "info", "sessionId": sessionID})
-	if resp["type"] == "error" {
-		p.t.Fatalf("awaitPendingInput info failed: %v", resp["error"])
-	}
-	info := parseSession(p.t, resp["session"])
-	if match(info.PendingInput) {
-		return info.PendingInput
-	}
-
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		ev, ok := sub.nextWithin(time.Until(deadline))
-		if !ok {
-			break
-		}
-		val := strVal(ev, "pendingInput")
-		if match(val) {
-			return val
-		}
-	}
-
-	resp = p.send(Msg{"type": "info", "sessionId": sessionID})
-	info = parseSession(p.t, resp["session"])
-	p.t.Fatalf("awaitPendingInput(%s): timed out after %v, pendingInput was %q",
-		sessionID, timeout, info.PendingInput)
-	return ""
+func (sc *socketConn) sendOn(conn net.Conn, scanner *bufio.Scanner, msg Msg) Msg {
+	sc.t.Helper()
+	msg["id"] = int(sc.nextID.Add(1))
+	return sc.doSend(conn, scanner, msg, 10*time.Second)
 }
 
 // --- Subscribe ---
@@ -889,19 +552,19 @@ type subscription struct {
 
 func (s *subscription) close() { s.conn.Close() }
 
-func (p *testPool) subscribe(opts Msg) *subscription {
-	p.t.Helper()
+func (sc *socketConn) subscribe(opts Msg) *subscription {
+	sc.t.Helper()
 	opts["type"] = "subscribe"
-	conn, scanner := p.newConn()
+	conn, scanner := sc.newConn()
 
 	data, _ := json.Marshal(opts)
 	data = append(data, '\n')
 	conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 	if _, err := conn.Write(data); err != nil {
-		p.t.Fatalf("subscribe write: %v", err)
+		sc.t.Fatalf("subscribe write: %v", err)
 	}
 
-	return &subscription{t: p.t, conn: conn, scanner: scanner}
+	return &subscription{t: sc.t, conn: conn, scanner: scanner}
 }
 
 func (s *subscription) resubscribe(opts Msg) {

--- a/tests/integration/offload_test.go
+++ b/tests/integration/offload_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 func TestOffload(t *testing.T) {
-	pool := setupCLIPool(t, 2)
+	pool := setupPool(t, 2)
 
 	var s1, s2 string
 
@@ -60,7 +60,6 @@ func TestOffload(t *testing.T) {
 		pool.run("followup", "--session", s2, "--prompt", "respond with exactly: touched")
 		pool.waitForIdle(s2, 300*time.Second)
 
-		// Start s3 — s1 should be evicted
 		r3 := pool.runJSON("start", "--prompt", "respond with exactly: eviction")
 		s3 := strVal(r3, "sessionId")
 
@@ -73,7 +72,6 @@ func TestOffload(t *testing.T) {
 			t.Fatalf("offloaded session should have no PID, got %v", info.PID)
 		}
 
-		// Archive s3 to free slot for later steps
 		pool.run("archive", "--session", s3)
 	})
 
@@ -130,7 +128,6 @@ func TestOffload(t *testing.T) {
 	})
 
 	t.Run("archive idle session", func(t *testing.T) {
-		// s2 is offloaded after process death
 		result := pool.run("archive", "--session", s2)
 		assertExitOK(t, result)
 
@@ -149,7 +146,6 @@ func TestOffload(t *testing.T) {
 			t.Fatal("archived session should not appear in default ls")
 		}
 
-		// With --archived flag, it should be visible
 		archivedSessions := pool.listSessions("--archived")
 		s, found := findSession(archivedSessions, s2)
 		if !found {
@@ -187,7 +183,6 @@ func TestOffload(t *testing.T) {
 	})
 
 	t.Run("unarchive on non-archived errors", func(t *testing.T) {
-		// s1 is idle, not archived
 		result := pool.run("unarchive", "--session", s1)
 		assertExitError(t, result)
 	})
@@ -209,7 +204,6 @@ func TestOffload(t *testing.T) {
 	})
 
 	t.Run("archive queued session cancels and archives", func(t *testing.T) {
-		// Restore both sessions
 		pool.run("unarchive", "--session", s1)
 		pool.run("unarchive", "--session", s2)
 		pool.run("followup", "--session", s1, "--prompt", "respond with exactly: fill1")

--- a/tests/integration/parent_child_test.go
+++ b/tests/integration/parent_child_test.go
@@ -43,7 +43,7 @@ import (
 )
 
 func TestParentChild(t *testing.T) {
-	pool := setupCLIPool(t, 3)
+	pool := setupPool(t, 3)
 
 	var s1, s2, s3, s4 string
 
@@ -91,7 +91,6 @@ func TestParentChild(t *testing.T) {
 
 	t.Run("start second child of root", func(t *testing.T) {
 		// Pool is full (3 slots). Evict s3 (least recently used) by starting s4.
-		// s3 should be offloaded since s1 and s2 were touched more recently.
 		resp := pool.runJSON("start", "--prompt", "respond with exactly: child2", "--parent", s1)
 		s4 = strVal(resp, "sessionId")
 		pool.waitForIdle(s4, 300*time.Second)
@@ -115,7 +114,6 @@ func TestParentChild(t *testing.T) {
 			}
 		}
 
-		// s2 should have s3 as child (even if s3 is offloaded)
 		if len(child2.Children) != 1 {
 			t.Fatalf("expected 1 child for s2, got %d", len(child2.Children))
 		}
@@ -125,12 +123,10 @@ func TestParentChild(t *testing.T) {
 	})
 
 	t.Run("ls without parent from non-Claude caller shows all", func(t *testing.T) {
-		// Non-Claude caller (no CLAUDE_POOL_SESSION_ID) — shows all top-level sessions
 		sessions := pool.listSessions()
 		if len(sessions) == 0 {
 			t.Fatal("ls should return sessions")
 		}
-		// Should include s1 as a top-level session
 		if _, found := findSession(sessions, s1); !found {
 			t.Fatal("expected s1 in top-level ls")
 		}
@@ -138,14 +134,12 @@ func TestParentChild(t *testing.T) {
 
 	t.Run("ls with parent filter shows direct children", func(t *testing.T) {
 		sessions := pool.listSessions("--parent", s1)
-		// Should show s2 and s4 (direct children of s1)
 		if _, found := findSession(sessions, s2); !found {
 			t.Fatal("expected s2 in ls --parent s1")
 		}
 		if _, found := findSession(sessions, s4); !found {
 			t.Fatal("expected s4 in ls --parent s1")
 		}
-		// s3 is a grandchild, should NOT appear at top level
 		if _, found := findSession(sessions, s3); found {
 			t.Fatal("s3 (grandchild) should not appear in --parent s1")
 		}
@@ -163,7 +157,6 @@ func TestParentChild(t *testing.T) {
 			t.Fatalf("expected at least 2 children in tree, got %d", len(root.Children))
 		}
 
-		// s2 should have s3 nested
 		for _, c := range root.Children {
 			if c.SessionID == s2 {
 				if len(c.Children) != 1 || c.Children[0].SessionID != s3 {
@@ -174,7 +167,6 @@ func TestParentChild(t *testing.T) {
 	})
 
 	t.Run("child auto-detects parent from env", func(t *testing.T) {
-		// Run start with CLAUDE_POOL_SESSION_ID=s1 — parent should auto-detect
 		resp := pool.runInSessionJSON(s1, "start", "--prompt", "respond with exactly: auto-child")
 		autoChild := strVal(resp, "sessionId")
 
@@ -189,7 +181,6 @@ func TestParentChild(t *testing.T) {
 	})
 
 	t.Run("explicit parent overrides env", func(t *testing.T) {
-		// CLAUDE_POOL_SESSION_ID=s1 but --parent s2 should win
 		resp := pool.runInSessionJSON(s1, "start", "--prompt", "respond with exactly: explicit", "--parent", s2)
 		explicitChild := strVal(resp, "sessionId")
 
@@ -204,7 +195,6 @@ func TestParentChild(t *testing.T) {
 	})
 
 	t.Run("parent none disables auto-detection", func(t *testing.T) {
-		// CLAUDE_POOL_SESSION_ID=s1 but --parent none → no parent
 		resp := pool.runInSessionJSON(s1, "start", "--prompt", "respond with exactly: orphan", "--parent", "none")
 		orphan := strVal(resp, "sessionId")
 
@@ -225,14 +215,12 @@ func TestParentChild(t *testing.T) {
 				t.Fatalf("expected only idle sessions with --status idle, got %q", s.Status)
 			}
 		}
-		// At least one session should be idle
 		if len(sessions) == 0 {
 			t.Fatal("expected at least one idle session")
 		}
 	})
 
 	t.Run("wait with parent filter", func(t *testing.T) {
-		// Start a child of s1 and wait for it via --parent
 		resp := pool.runJSON("start", "--prompt", "respond with exactly: wait-parent-test", "--parent", s1)
 		childSid := strVal(resp, "sessionId")
 
@@ -246,17 +234,14 @@ func TestParentChild(t *testing.T) {
 	})
 
 	t.Run("ls parent none from session context shows all", func(t *testing.T) {
-		// From a Claude session (CLAUDE_POOL_SESSION_ID set), --parent none shows all
 		resp := pool.runInSessionJSON(s1, "ls", "--parent", "none")
 		sessions := parseSessions(t, resp)
-		// Should include s1 itself (top-level)
 		if _, found := findSession(sessions, s1); !found {
 			t.Fatal("expected s1 in ls --parent none from session context")
 		}
 	})
 
 	t.Run("ls from session context shows owned children", func(t *testing.T) {
-		// ls as s1 — should show s2, s4 (direct children)
 		resp := pool.runInSessionJSON(s1, "ls")
 		sessions := parseSessions(t, resp)
 
@@ -275,7 +260,6 @@ func TestParentChild(t *testing.T) {
 	})
 
 	t.Run("archive with unarchived children errors", func(t *testing.T) {
-		// s2 has child s3 (offloaded but not archived)
 		result := pool.run("archive", "--session", s2)
 		assertExitError(t, result)
 
@@ -294,7 +278,6 @@ func TestParentChild(t *testing.T) {
 	})
 
 	t.Run("archive parent after children archived", func(t *testing.T) {
-		// s2's child (s3) is now archived — s2 can be archived
 		result := pool.run("archive", "--session", s2)
 		assertExitOK(t, result)
 
@@ -303,7 +286,6 @@ func TestParentChild(t *testing.T) {
 	})
 
 	t.Run("recursive archive archives entire subtree", func(t *testing.T) {
-		// Unarchive s2 and s3 to test recursive from s1
 		pool.run("unarchive", "--session", s2)
 		pool.run("unarchive", "--session", s3)
 
@@ -315,13 +297,11 @@ func TestParentChild(t *testing.T) {
 			assertStatus(t, info, "archived")
 		}
 
-		// Default ls should be empty
 		sessions := pool.listSessions()
 		if len(sessions) != 0 {
 			t.Fatalf("expected 0 sessions after recursive archive, got %d", len(sessions))
 		}
 
-		// ls with --archived shows all
 		archivedSessions := pool.listSessions("--archived")
 		if len(archivedSessions) < 4 {
 			t.Fatalf("expected at least 4 with --archived, got %d", len(archivedSessions))

--- a/tests/integration/pool_test.go
+++ b/tests/integration/pool_test.go
@@ -5,29 +5,30 @@ package integration
 // Pool size: 2
 //
 // Tests pool-level CLI commands: init, ping, health, config, resize, destroy,
-// and re-init with session restoration. Uses setupCLIDaemon because the first
-// steps need to interact with the daemon before init.
+// and re-init with session restoration. Uses newPool because the first steps
+// test behavior before init.
 //
 // Flow:
 //
-//   1.  "ping before init"
-//   2.  "config read before init"
-//   3.  "config set"
-//   4.  "init"
-//   5.  "init errors if already running"
-//   6.  "ping after init"
-//   7.  "health"
-//   8.  "pools lists known pools"
-//   9.  "resize rejects size 0"
-//  10.  "resize up to 3"
-//  11.  "resize down to 1"
-//  12.  "resize reversal clears pending kill tokens"
-//  13.  "deferred eviction of processing sessions"
-//  14.  "resize respects pins"
-//  15.  "destroy without confirm errors"
-//  16.  "destroy"
-//  17.  "re-init restores sessions and config"
-//  18.  "re-init with no-restore"
+//   1.  "ping before init fails"
+//   2.  "pools before init"
+//   3.  "init"
+//   4.  "init errors if already running"
+//   5.  "ping after init"
+//   6.  "health"
+//   7.  "pools lists the pool"
+//   8.  "config read"
+//   9.  "config set"
+//  10.  "resize rejects size 0"
+//  11.  "resize up to 3"
+//  12.  "resize down to 1"
+//  13.  "resize reversal clears pending kill tokens"
+//  14.  "deferred eviction of processing sessions"
+//  15.  "resize respects pins"
+//  16.  "destroy without confirm errors"
+//  17.  "destroy"
+//  18.  "re-init restores sessions and config"
+//  19.  "re-init with no-restore"
 
 import (
 	"testing"
@@ -35,49 +36,27 @@ import (
 )
 
 func TestPool(t *testing.T) {
-	pool := setupCLIDaemon(t, 2)
+	pool := newPool(t)
 
-	t.Run("ping before init", func(t *testing.T) {
+	t.Run("ping before init fails", func(t *testing.T) {
+		// No daemon running yet — ping should fail
 		result := pool.run("ping")
-		assertExitOK(t, result)
+		assertExitError(t, result)
 	})
 
-	t.Run("config read before init", func(t *testing.T) {
-		resp := pool.runJSON("config")
-		cfg, ok := resp["config"].(map[string]any)
-		if !ok {
-			t.Fatalf("expected config object, got %T", resp["config"])
-		}
-		assertContains(t, strVal(cfg, "flags"), "haiku")
-		if numVal(cfg, "size") != 2 {
-			t.Fatalf("expected size 2, got %v", numVal(cfg, "size"))
-		}
-	})
-
-	t.Run("config set", func(t *testing.T) {
-		resp := pool.runJSON("config", "--set", "size=4")
-		cfg, _ := resp["config"].(map[string]any)
-		if numVal(cfg, "size") != 4 {
-			t.Fatalf("expected size 4 after set, got %v", numVal(cfg, "size"))
-		}
-
-		// Verify persistence
-		readResp := pool.runJSON("config")
-		readCfg, _ := readResp["config"].(map[string]any)
-		if numVal(readCfg, "size") != 4 {
-			t.Fatalf("config not persisted: expected 4, got %v", numVal(readCfg, "size"))
-		}
-
-		// Restore to 2
-		pool.run("config", "--set", "size=2")
+	t.Run("pools before init", func(t *testing.T) {
+		// Registry doesn't exist yet — should succeed with empty list or no error
+		result := pool.run("pools", "--json")
+		_ = result
 	})
 
 	var s1, s2 string
 
 	t.Run("init", func(t *testing.T) {
-		resp := pool.runJSON("init", "--size", "2")
+		resp := pool.runJSON("init", "--size", "2",
+			"--dir", pool.workDir,
+			"--flags", "--dangerously-skip-permissions --model haiku")
 
-		// Init returns pool state (same structure as health)
 		poolState, ok := resp["pool"].(map[string]any)
 		if !ok {
 			t.Fatalf("expected pool object in init response, got %v", resp)
@@ -86,10 +65,8 @@ func TestPool(t *testing.T) {
 			t.Fatalf("expected pool size 2, got %v", numVal(poolState, "size"))
 		}
 
-		// Wait for both sessions to become idle
 		pool.waitForIdleCount(2, 90*time.Second)
 
-		// Get session IDs for later steps
 		sessions := pool.listSessions()
 		if len(sessions) < 2 {
 			t.Fatalf("expected at least 2 sessions, got %d", len(sessions))
@@ -123,12 +100,39 @@ func TestPool(t *testing.T) {
 		}
 	})
 
-	t.Run("pools lists known pools", func(t *testing.T) {
+	t.Run("pools lists the pool", func(t *testing.T) {
 		resp := pool.runJSON("pools")
-		// Should list at least our test pool
 		if resp == nil {
 			t.Fatal("expected non-nil pools response")
 		}
+	})
+
+	t.Run("config read", func(t *testing.T) {
+		resp := pool.runJSON("config")
+		cfg, ok := resp["config"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected config object, got %T", resp["config"])
+		}
+		assertContains(t, strVal(cfg, "flags"), "haiku")
+		if numVal(cfg, "size") != 2 {
+			t.Fatalf("expected size 2, got %v", numVal(cfg, "size"))
+		}
+	})
+
+	t.Run("config set", func(t *testing.T) {
+		resp := pool.runJSON("config", "--set", "size=4")
+		cfg, _ := resp["config"].(map[string]any)
+		if numVal(cfg, "size") != 4 {
+			t.Fatalf("expected size 4 after set, got %v", numVal(cfg, "size"))
+		}
+
+		readResp := pool.runJSON("config")
+		readCfg, _ := readResp["config"].(map[string]any)
+		if numVal(readCfg, "size") != 4 {
+			t.Fatalf("config not persisted: expected 4, got %v", numVal(readCfg, "size"))
+		}
+
+		pool.run("config", "--set", "size=2")
 	})
 
 	t.Run("resize rejects size 0", func(t *testing.T) {
@@ -143,13 +147,11 @@ func TestPool(t *testing.T) {
 	})
 
 	t.Run("resize down to 1", func(t *testing.T) {
-		// Keep s1 processing so we can observe async slot reclamation
 		pool.run("followup", "--session", s1, "--prompt", "run the bash command: sleep 60")
 		pool.waitForStatus(s1, "processing", 15*time.Second)
 
 		pool.run("resize", "--size", "1")
 
-		// Stop s1 so its slot can be reclaimed
 		pool.run("stop", "--session", s1)
 		pool.waitForPoolSize(1, 15*time.Second)
 	})
@@ -170,17 +172,14 @@ func TestPool(t *testing.T) {
 		}
 		sa, sb := idle[0], idle[1]
 
-		// Make both processing so kill tokens can't be consumed
 		pool.run("followup", "--session", sa, "--prompt", "run the bash command: sleep 60")
 		pool.run("followup", "--session", sb, "--prompt", "run the bash command: sleep 60")
 		pool.waitForStatus(sa, "processing", 15*time.Second)
 		pool.waitForStatus(sb, "processing", 15*time.Second)
 
-		// Resize to 1, then back to 2 — token must be cleared
 		pool.run("resize", "--size", "1")
 		pool.run("resize", "--size", "2")
 
-		// Both must still be processing (no premature eviction)
 		infoA := pool.getSessionInfo(sa)
 		infoB := pool.getSessionInfo(sb)
 		if infoA.Status != "processing" {
@@ -213,10 +212,8 @@ func TestPool(t *testing.T) {
 		pool.waitForStatus(sa, "processing", 15*time.Second)
 		pool.waitForStatus(sb, "processing", 15*time.Second)
 
-		// Resize to 1 — kill token lingers
 		pool.run("resize", "--size", "1")
 
-		// Stop both — lingering token should evict one
 		pool.run("stop", "--session", sa)
 		pool.run("stop", "--session", sb)
 		pool.waitForPoolSize(1, 15*time.Second)
@@ -243,7 +240,6 @@ func TestPool(t *testing.T) {
 		pool.run("resize", "--size", "1")
 		pool.waitForPoolSize(1, 15*time.Second)
 
-		// Pinned session must survive
 		info := pool.getSessionInfo(pinned)
 		if info.Status == "offloaded" || info.Status == "archived" {
 			t.Fatalf("pinned session was evicted: status=%s", info.Status)
@@ -264,18 +260,9 @@ func TestPool(t *testing.T) {
 
 	t.Run("re-init restores sessions and config", func(t *testing.T) {
 		pool.awaitSocketGone(10 * time.Second)
-		pool.startDaemon()
 
-		// Config should survive restart
-		resp := pool.runJSON("config")
-		cfg, _ := resp["config"].(map[string]any)
-		if numVal(cfg, "size") != 2 {
-			t.Fatalf("config size not persisted: expected 2, got %v", numVal(cfg, "size"))
-		}
-		assertContains(t, strVal(cfg, "flags"), "haiku")
-
-		initResp := pool.runJSON("init", "--size", "2")
-		poolState, ok := initResp["pool"].(map[string]any)
+		resp := pool.runJSON("init", "--size", "2", "--dir", pool.workDir)
+		poolState, ok := resp["pool"].(map[string]any)
 		if !ok {
 			t.Fatalf("expected pool object in init response")
 		}
@@ -284,6 +271,11 @@ func TestPool(t *testing.T) {
 		}
 
 		pool.waitForIdleCount(2, 90*time.Second)
+
+		// Config survives destroy+init cycle
+		cfgResp := pool.runJSON("config")
+		cfg, _ := cfgResp["config"].(map[string]any)
+		assertContains(t, strVal(cfg, "flags"), "haiku")
 
 		// At least one session must be restored (has Claude UUID from prior run)
 		sessions := pool.listSessions("--verbosity", "full")
@@ -302,12 +294,10 @@ func TestPool(t *testing.T) {
 	t.Run("re-init with no-restore", func(t *testing.T) {
 		pool.run("destroy", "--confirm")
 		pool.awaitSocketGone(10 * time.Second)
-		pool.startDaemon()
 
-		pool.runJSON("init", "--size", "2", "--no-restore")
+		pool.runJSON("init", "--size", "2", "--dir", pool.workDir, "--no-restore")
 		pool.waitForIdleCount(2, 90*time.Second)
 
-		// All sessions should be fresh — none should match pre-destroy IDs
 		sessions := pool.listSessions("--verbosity", "full")
 		for _, s := range sessions {
 			if s.SessionID == s1 || s.SessionID == s2 {

--- a/tests/integration/session_test.go
+++ b/tests/integration/session_test.go
@@ -46,7 +46,7 @@ import (
 )
 
 func TestSession(t *testing.T) {
-	pool := setupCLIPool(t, 3)
+	pool := setupPool(t, 3)
 
 	var s1 string
 
@@ -258,7 +258,6 @@ func TestSession(t *testing.T) {
 		s2 = strVal(startResp, "sessionId")
 		pool.waitForStatus(s2, "processing", 15*time.Second)
 
-		// Followup on processing session should error (spec says: "Errors if session is busy")
 		result := pool.run("followup", "--session", s2, "--prompt", "ignore", "--json")
 		assertExitError(t, result)
 	})
@@ -278,7 +277,6 @@ func TestSession(t *testing.T) {
 		sid := strVal(resp, "sessionId")
 		assertNonEmpty(t, "block sessionId", sid)
 
-		// Clean up
 		pool.run("archive", "--session", sid)
 	})
 
@@ -287,7 +285,6 @@ func TestSession(t *testing.T) {
 		sid := strVal(startResp, "sessionId")
 		pool.waitForStatus(sid, "processing", 15*time.Second)
 
-		// 1ms timeout — guaranteed to expire
 		result := pool.run("wait", "--session", sid, "--timeout", "1", "--json")
 		assertExitError(t, result)
 
@@ -328,7 +325,6 @@ func TestSession(t *testing.T) {
 	})
 
 	t.Run("stop on idle errors", func(t *testing.T) {
-		// s1 is idle — stop should error (spec: "Errors if session is not processing or queued")
 		result := pool.run("stop", "--session", s1)
 		assertExitError(t, result)
 	})

--- a/tests/integration/slots_test.go
+++ b/tests/integration/slots_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestSlots(t *testing.T) {
-	pool := setupCLIPool(t, 2)
+	pool := setupPool(t, 2)
 
 	var s1, s2 string
 
@@ -76,7 +76,6 @@ func TestSlots(t *testing.T) {
 	})
 
 	t.Run("capture on fresh-queued session errors", func(t *testing.T) {
-		// s3 is queued — no UUID, no terminal
 		for _, args := range [][]string{
 			{"--source", "jsonl"},
 			{"--source", "jsonl", "--detail", "raw"},
@@ -93,7 +92,6 @@ func TestSlots(t *testing.T) {
 		result := pool.run("stop", "--session", s3)
 		assertExitOK(t, result)
 
-		// Queued session that never got a slot should be gone
 		infoResult := pool.run("info", "--session", s3, "--json")
 		assertExitError(t, infoResult)
 
@@ -106,7 +104,6 @@ func TestSlots(t *testing.T) {
 	var s4 string
 
 	t.Run("queued session gets slot when one frees", func(t *testing.T) {
-		// s1 and s2 are still processing
 		resp := pool.runJSON("start", "--prompt", "respond with exactly: dequeued")
 		s4 = strVal(resp, "sessionId")
 
@@ -133,11 +130,9 @@ func TestSlots(t *testing.T) {
 		pool.waitForStatus(s2, "idle", 10*time.Second)
 		pool.waitForStatus(s4, "idle", 10*time.Second)
 
-		// High priority = evicted last, low priority = evicted first
 		pool.run("set", "--session", s2, "--priority", "10")
 		pool.run("set", "--session", s4, "--priority", "-1")
 
-		// Start new — pool full, idle session must be evicted
 		resp := pool.runJSON("start", "--prompt", "respond with exactly: priority")
 		s5 := strVal(resp, "sessionId")
 
@@ -151,7 +146,6 @@ func TestSlots(t *testing.T) {
 
 		pool.waitForIdle(s5, 300*time.Second)
 
-		// Reset priority
 		pool.run("set", "--session", s2, "--priority", "0")
 	})
 
@@ -178,7 +172,6 @@ func TestSlots(t *testing.T) {
 		pool.run("followup", "--session", slotB, "--prompt", "respond with exactly: recent")
 		pool.waitForIdle(slotB, 300*time.Second)
 
-		// Start new — slotA (older) should be evicted
 		resp := pool.runJSON("start", "--prompt", "respond with exactly: lru")
 		newSid := strVal(resp, "sessionId")
 
@@ -208,7 +201,6 @@ func TestSlots(t *testing.T) {
 
 		pool.run("set", "--session", pinTarget, "--pinned", "300")
 
-		// Start new — unpinned should be evicted
 		resp := pool.runJSON("start", "--prompt", "respond with exactly: pintest")
 		newSid := strVal(resp, "sessionId")
 
@@ -250,7 +242,6 @@ func TestSlots(t *testing.T) {
 	})
 
 	t.Run("followup on queued errors", func(t *testing.T) {
-		// Fill both slots with processing sessions
 		sessions := pool.listSessions()
 		var idle []string
 		for _, s := range sessions {
@@ -272,7 +263,6 @@ func TestSlots(t *testing.T) {
 			t.Fatalf("expected queued, got %q", strVal(resp, "status"))
 		}
 
-		// Followup on queued should error
 		result := pool.run("followup", "--session", queuedSid, "--prompt", "nope")
 		assertExitError(t, result)
 

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -7,9 +7,8 @@ package integration
 // This flow tests the subscribe system: receiving events, applying filters, dynamically
 // updating subscriptions, and verifying the "updated" event type for property changes.
 //
-// Subscribe is an API-only feature (not exposed in CLI), so this test uses the socket
-// API directly. Uses new spec field names: "parent" not "parentId", "set" not
-// "pin"/"unpin"/"set-priority".
+// Subscribe is an API-only feature (not exposed in CLI). The pool is created
+// via CLI init, then pool.dial() opens a socket connection for API commands.
 //
 // Flow:
 //
@@ -34,15 +33,15 @@ import (
 )
 
 func TestSubscribe(t *testing.T) {
-	pool := setupPool(t, 2)
+	p := setupPool(t, 2)
+	sc := p.dial()
 
 	var s1, s2 string
 
 	t.Run("subscribe receives status events", func(t *testing.T) {
-		sub := pool.subscribe(Msg{})
+		sub := sc.subscribe(Msg{})
 
-		resp := pool.send(Msg{"type": "start", "prompt": "respond with exactly: sub1"})
-		assertNotError(t, resp)
+		resp := p.runJSON("start", "--prompt", "respond with exactly: sub1")
 		s1 = strVal(resp, "sessionId")
 
 		var sawCreated, sawIdle bool
@@ -71,10 +70,9 @@ func TestSubscribe(t *testing.T) {
 	})
 
 	t.Run("subscribe receives created events with parent", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"sessions": []string{}, "events": []string{"created"}})
+		sub := sc.subscribe(Msg{"sessions": []string{}, "events": []string{"created"}})
 
-		resp := pool.send(Msg{"type": "start", "prompt": "respond with exactly: sub2", "parent": s1})
-		assertNotError(t, resp)
+		resp := p.runJSON("start", "--prompt", "respond with exactly: sub2", "--parent", s1)
 		s2 = strVal(resp, "sessionId")
 
 		for i := 0; i < 10; i++ {
@@ -90,14 +88,14 @@ func TestSubscribe(t *testing.T) {
 			}
 		}
 
-		pool.awaitStatus(s2, "idle", 60*time.Second)
+		p.waitForStatus(s2, "idle", 60*time.Second)
 	})
 
 	t.Run("subscribe receives pool events", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"events": []string{"pool"}})
+		sub := sc.subscribe(Msg{"events": []string{"pool"}})
 		defer sub.close()
 
-		pool.send(Msg{"type": "resize", "size": 3})
+		sc.send(Msg{"type": "resize", "size": 3})
 
 		ev, ok := sub.nextWithin(10 * time.Second)
 		if !ok {
@@ -107,15 +105,15 @@ func TestSubscribe(t *testing.T) {
 			t.Fatalf("expected pool event, got %q", strVal(ev, "event"))
 		}
 
-		pool.send(Msg{"type": "resize", "size": 2})
+		sc.send(Msg{"type": "resize", "size": 2})
 		sub.drain()
 	})
 
 	t.Run("filter by sessions", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"sessions": []string{s1}})
+		sub := sc.subscribe(Msg{"sessions": []string{s1}})
 
-		pool.send(Msg{"type": "followup", "sessionId": s2, "prompt": "respond with exactly: filtered"})
-		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "respond with exactly: visible"})
+		p.run("followup", "--session", s2, "--prompt", "respond with exactly: filtered")
+		p.run("followup", "--session", s1, "--prompt", "respond with exactly: visible")
 
 		var sawS1, sawS2 bool
 		for i := 0; i < 20; i++ {
@@ -137,18 +135,17 @@ func TestSubscribe(t *testing.T) {
 			t.Fatal("should not receive events for s2 with session filter")
 		}
 
-		pool.awaitStatus(s1, "idle", 60*time.Second)
-		pool.awaitStatus(s2, "idle", 60*time.Second)
+		p.waitForStatus(s1, "idle", 60*time.Second)
+		p.waitForStatus(s2, "idle", 60*time.Second)
 	})
 
 	t.Run("filter by events", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"events": []string{"status"}})
+		sub := sc.subscribe(Msg{"events": []string{"status"}})
 
-		pool.send(Msg{"type": "offload", "sessionId": s2})
-		pool.awaitStatus(s2, "offloaded", 10*time.Second)
+		sc.send(Msg{"type": "offload", "sessionId": s2})
+		p.waitForStatus(s2, "offloaded", 10*time.Second)
 
-		r := pool.send(Msg{"type": "start", "prompt": "respond with exactly: eventfilter"})
-		assertNotError(t, r)
+		r := p.runJSON("start", "--prompt", "respond with exactly: eventfilter")
 		s3 := strVal(r, "sessionId")
 
 		var sawStatus, sawCreated bool
@@ -174,15 +171,15 @@ func TestSubscribe(t *testing.T) {
 			t.Fatal("should not receive created events with events=[status] filter")
 		}
 
-		pool.send(Msg{"type": "followup", "sessionId": s2, "prompt": "respond with exactly: back"})
-		pool.awaitStatus(s2, "idle", 60*time.Second)
-		pool.send(Msg{"type": "archive", "sessionId": s3})
+		p.run("followup", "--session", s2, "--prompt", "respond with exactly: back")
+		p.waitForStatus(s2, "idle", 60*time.Second)
+		p.run("archive", "--session", s3)
 	})
 
 	t.Run("filter by statuses", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"statuses": []string{"idle"}})
+		sub := sc.subscribe(Msg{"statuses": []string{"idle"}})
 
-		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "respond with exactly: statusfilter"})
+		p.run("followup", "--session", s1, "--prompt", "respond with exactly: statusfilter")
 
 		var sawIdle, sawProcessing bool
 		for i := 0; i < 10; i++ {
@@ -207,10 +204,10 @@ func TestSubscribe(t *testing.T) {
 	})
 
 	t.Run("filters are ANDed", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"sessions": []string{s1}, "statuses": []string{"idle"}})
+		sub := sc.subscribe(Msg{"sessions": []string{s1}, "statuses": []string{"idle"}})
 
-		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "respond with exactly: and1"})
-		pool.send(Msg{"type": "followup", "sessionId": s2, "prompt": "respond with exactly: and2"})
+		p.run("followup", "--session", s1, "--prompt", "respond with exactly: and1")
+		p.run("followup", "--session", s2, "--prompt", "respond with exactly: and2")
 
 		var matched bool
 		for i := 0; i < 10; i++ {
@@ -233,18 +230,18 @@ func TestSubscribe(t *testing.T) {
 			t.Fatal("expected s1 idle event")
 		}
 
-		pool.awaitStatus(s1, "idle", 60*time.Second)
-		pool.awaitStatus(s2, "idle", 60*time.Second)
+		p.waitForStatus(s1, "idle", 60*time.Second)
+		p.waitForStatus(s2, "idle", 60*time.Second)
 	})
 
 	t.Run("re-subscribe replaces filters", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"sessions": []string{s1}})
+		sub := sc.subscribe(Msg{"sessions": []string{s1}})
 		defer sub.close()
 
 		sub.resubscribe(Msg{"sessions": []string{s2}})
 
-		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "respond with exactly: old"})
-		pool.send(Msg{"type": "followup", "sessionId": s2, "prompt": "respond with exactly: new"})
+		p.run("followup", "--session", s1, "--prompt", "respond with exactly: old")
+		p.run("followup", "--session", s2, "--prompt", "respond with exactly: new")
 
 		var sawS1, sawS2 bool
 		for i := 0; i < 20; i++ {
@@ -266,14 +263,14 @@ func TestSubscribe(t *testing.T) {
 			t.Fatal("expected s2 events after re-subscribe")
 		}
 
-		pool.awaitStatus(s1, "idle", 60*time.Second)
-		pool.awaitStatus(s2, "idle", 60*time.Second)
+		p.waitForStatus(s1, "idle", 60*time.Second)
+		p.waitForStatus(s2, "idle", 60*time.Second)
 	})
 
 	t.Run("updated event — priority change", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"events": []string{"updated"}})
+		sub := sc.subscribe(Msg{"events": []string{"updated"}})
 
-		pool.send(Msg{"type": "set", "sessionId": s1, "priority": 5})
+		sc.send(Msg{"type": "set", "sessionId": s1, "priority": 5})
 
 		ev, ok := sub.nextWithin(10 * time.Second)
 		if !ok {
@@ -291,14 +288,14 @@ func TestSubscribe(t *testing.T) {
 			t.Fatalf("expected priority 5 in changes, got %v", changes["priority"])
 		}
 
-		pool.send(Msg{"type": "set", "sessionId": s1, "priority": 0})
+		sc.send(Msg{"type": "set", "sessionId": s1, "priority": 0})
 		sub.drain()
 	})
 
 	t.Run("updated event — pin/unpin", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"events": []string{"updated"}})
+		sub := sc.subscribe(Msg{"events": []string{"updated"}})
 
-		pool.send(Msg{"type": "set", "sessionId": s1, "pinned": 300})
+		sc.send(Msg{"type": "set", "sessionId": s1, "pinned": 300})
 		ev, ok := sub.nextWithin(10 * time.Second)
 		if !ok {
 			t.Fatal("expected updated event for pin")
@@ -308,7 +305,7 @@ func TestSubscribe(t *testing.T) {
 			t.Fatal("expected pinned=true in changes")
 		}
 
-		pool.send(Msg{"type": "set", "sessionId": s1, "pinned": false})
+		sc.send(Msg{"type": "set", "sessionId": s1, "pinned": false})
 		ev, ok = sub.nextWithin(10 * time.Second)
 		if !ok {
 			t.Fatal("expected updated event for unpin")
@@ -320,13 +317,10 @@ func TestSubscribe(t *testing.T) {
 	})
 
 	t.Run("updated event — cwd change", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"events": []string{"updated"}, "fields": []string{"cwd"}})
+		sub := sc.subscribe(Msg{"events": []string{"updated"}, "fields": []string{"cwd"}})
 
-		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "run these bash commands: mkdir -p cwd_sub_test && cd cwd_sub_test"})
-		pool.sendLong(
-			Msg{"type": "wait", "sessionId": s1, "timeout": 60000},
-			75*time.Second,
-		)
+		p.run("followup", "--session", s1, "--prompt", "run these bash commands: mkdir -p cwd_sub_test && cd cwd_sub_test")
+		p.waitForIdle(s1, 60*time.Second)
 
 		ev, ok := sub.nextWithin(10 * time.Second)
 		if !ok {
@@ -340,9 +334,9 @@ func TestSubscribe(t *testing.T) {
 	})
 
 	t.Run("updated event — fields filter", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"events": []string{"updated"}, "fields": []string{"priority"}})
+		sub := sc.subscribe(Msg{"events": []string{"updated"}, "fields": []string{"priority"}})
 
-		pool.send(Msg{"type": "set", "sessionId": s1, "priority": 3})
+		sc.send(Msg{"type": "set", "sessionId": s1, "priority": 3})
 		ev, ok := sub.nextWithin(10 * time.Second)
 		if !ok {
 			t.Fatal("expected updated event for priority change")
@@ -352,23 +346,23 @@ func TestSubscribe(t *testing.T) {
 		}
 
 		// Pin should NOT trigger event (pinned not in fields filter)
-		pool.send(Msg{"type": "set", "sessionId": s1, "pinned": 300})
+		sc.send(Msg{"type": "set", "sessionId": s1, "pinned": 300})
 		_, ok = sub.nextWithin(2 * time.Second)
 		if ok {
 			t.Fatal("should not receive updated event for pin when fields=[priority]")
 		}
 
-		pool.send(Msg{"type": "set", "sessionId": s1, "pinned": false})
-		pool.send(Msg{"type": "set", "sessionId": s1, "priority": 0})
+		sc.send(Msg{"type": "set", "sessionId": s1, "pinned": false})
+		sc.send(Msg{"type": "set", "sessionId": s1, "priority": 0})
 	})
 
 	t.Run("archived and unarchived events", func(t *testing.T) {
-		sub := pool.subscribe(Msg{"events": []string{"archived", "unarchived"}})
+		sub := sc.subscribe(Msg{"events": []string{"archived", "unarchived"}})
 
-		pool.send(Msg{"type": "offload", "sessionId": s2})
-		pool.awaitStatus(s2, "offloaded", 10*time.Second)
+		sc.send(Msg{"type": "offload", "sessionId": s2})
+		p.waitForStatus(s2, "offloaded", 10*time.Second)
 
-		pool.send(Msg{"type": "archive", "sessionId": s2})
+		sc.send(Msg{"type": "archive", "sessionId": s2})
 		ev, ok := sub.nextWithin(10 * time.Second)
 		if !ok {
 			t.Fatal("expected archived event")
@@ -380,7 +374,7 @@ func TestSubscribe(t *testing.T) {
 			t.Fatalf("expected sessionId %s, got %q", s2, strVal(ev, "sessionId"))
 		}
 
-		pool.send(Msg{"type": "unarchive", "sessionId": s2})
+		sc.send(Msg{"type": "unarchive", "sessionId": s2})
 		ev, ok = sub.nextWithin(10 * time.Second)
 		if !ok {
 			t.Fatal("expected unarchived event")
@@ -389,16 +383,16 @@ func TestSubscribe(t *testing.T) {
 			t.Fatalf("expected unarchived event, got %q", strVal(ev, "event"))
 		}
 
-		pool.send(Msg{"type": "followup", "sessionId": s2, "prompt": "respond with exactly: back"})
-		pool.awaitStatus(s2, "idle", 60*time.Second)
+		p.run("followup", "--session", s2, "--prompt", "respond with exactly: back")
+		p.waitForStatus(s2, "idle", 60*time.Second)
 	})
 
 	t.Run("multiple concurrent subscribers", func(t *testing.T) {
-		sub1 := pool.subscribe(Msg{"sessions": []string{s1}})
-		sub2 := pool.subscribe(Msg{"sessions": []string{s2}})
+		sub1 := sc.subscribe(Msg{"sessions": []string{s1}})
+		sub2 := sc.subscribe(Msg{"sessions": []string{s2}})
 
-		pool.send(Msg{"type": "followup", "sessionId": s1, "prompt": "respond with exactly: multi1"})
-		pool.send(Msg{"type": "followup", "sessionId": s2, "prompt": "respond with exactly: multi2"})
+		p.run("followup", "--session", s1, "--prompt", "respond with exactly: multi1")
+		p.run("followup", "--session", s2, "--prompt", "respond with exactly: multi2")
 
 		var sub1SawS1, sub1SawS2 bool
 		for i := 0; i < 10; i++ {


### PR DESCRIPTION
## Summary
- Replace manual daemon start + synthetic registry with real `claude-pool-cli init`
- Single `pool` type replaces `cliPool` + `testPool` (-371 lines)
- Isolation via `CLAUDE_POOL_HOME` + `CLAUDE_POOL_DAEMON` env vars
- Socket tests (attach, subscribe) use `pool.dial()` after CLI setup
- TDD contract: tests fail until `init` CLI starts the daemon

## Test plan
- [x] `go vet ./tests/integration/` passes
- [ ] Tests expected to fail until CLAUDE_POOL_HOME support implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)