### PR TITLE
Set CLAUDE_POOL_TEST in integration tests

### DIFF
--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -238,7 +238,7 @@ func (p *pool) cliEnv() []string {
 	return append(os.Environ(),
 		"CLAUDE_POOL_HOME="+p.homeDir,
 		"CLAUDE_POOL_DAEMON="+daemonBinPath,
-		"CLAUDE_POOL_TEST=1", // Suppresses Open Cockpit hooks (session-pid registration, idle signals, etc.)
+		"CLAUDE_POOL_TEST=1",
 	)
 }
 


### PR DESCRIPTION
## Summary
- Set `CLAUDE_POOL_TEST=1` in test CLI env so it flows through to spawned Claude sessions
- Open Cockpit hooks check this var and skip registration (EliasSchlie/open-cockpit#405)
- Prevents test sessions from appearing in Open Cockpit

## Test plan
- [ ] Run integration tests → verify sessions no longer appear in OC

🤖 Generated with [Claude Code](https://claude.com/claude-code)