### PR TITLE
Fix init response shape and add verbosity to ToMsg

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -130,7 +130,7 @@ If a session was stopped before producing output, or if there is no assistant me
 | `size` | integer ≥ 1 | No | Number of slots. Falls back to `config.json` if omitted. |
 | `noRestore` | boolean | No | Skip restoring previously live sessions (default false). |
 
-**Response:** `{ type: "pool", pool }` — full pool state after init.
+**Response:** `{ type: "health", health }` — pool state after init (same format as `health`).
 
 **Behavior:** Initializes the pool daemon. Reads flags from `config.json`. Errors if pool already initialized (sessions are running). Updates `pools.json` registry.
 
@@ -311,10 +311,11 @@ Priority defaults to 0 for new sessions. Use `set-priority` to change it after c
 | `tree` | boolean | No | Show descendants as nested tree (default false = flat list of direct children) |
 | `archived` | boolean | No | Include archived sessions (default false = hidden) |
 | `statuses` | string[] | No | Filter by status (e.g. `["idle", "processing"]`). Omit for no filtering. |
+| `verbosity` | string | No | `"flat"` (default), `"nested"`, or `"full"`. See Session Object in SPEC.md. |
 
-**Response:** `{ type: "sessions", sessions }` — array of session info objects.
+**Response:** `{ type: "sessions", sessions }` — array of session objects at the requested verbosity.
 
-**Behavior:** Lists sessions. Each session includes: `sessionId`, `claudeUUID` (null if not yet discovered), `status`, `parentId`, `priority`, `cwd`, `spawnCwd`, `createdAt`, `pid`, `pinned`, `metadata`, `children` (array of child sessions, populated when `tree: true`).
+**Behavior:** Lists sessions. Fields included depend on verbosity (see SPEC.md Session Object table).
 - Default: returns direct children of the caller (excludes archived).
 - `tree: true`: returns children with their descendants nested recursively (each child has its own `children` array populated).
 - `all: true`: returns every session in the pool (flat list).
@@ -329,17 +330,18 @@ Priority defaults to 0 for new sessions. Use `set-priority` to change it after c
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `sessionId` | sessionId | Yes | Target session |
+| `verbosity` | string | No | `"flat"`, `"nested"`, or `"full"` (default). See Session Object in SPEC.md. |
 
-**Response:** `{ type: "session", session }` — a session object (see below).
+**Response:** `{ type: "session", session }` — a session object at the requested verbosity.
 
-**Behavior:** Returns a **session object** with all information about the session:
+**Behavior:** Returns a **session object** with information about the session. Fields depend on verbosity — see SPEC.md Session Object table. Example at default verbosity (`full`):
 
 ```json
 {
   "sessionId": "a7f2x9",
   "claudeUUID": "2947bf12-d307-4a1c-...",
   "status": "idle",
-  "parentId": null,
+  "parent": "",
   "priority": 0,
   "cwd": "/Users/me/project",
   "spawnCwd": "/Users/me",

--- a/internal/pool/handlers.go
+++ b/internal/pool/handlers.go
@@ -18,6 +18,13 @@ func parentFromReq(req api.Msg) string {
 	return v
 }
 
+func verbosityFromReq(req api.Msg, fallback string) string {
+	if v, _ := req["verbosity"].(string); v != "" {
+		return v
+	}
+	return fallback
+}
+
 // --- Config ---
 
 func (m *Manager) handleConfig(id any, req api.Msg) api.Msg {
@@ -75,8 +82,6 @@ func (m *Manager) handleInit(id any, req api.Msg) api.Msg {
 		liveSessions, offloadedSessions = m.loadPoolState()
 	}
 
-	sessions := make([]any, 0)
-
 	// Restore live sessions into slots first
 	restored := 0
 	log.Printf("[init] restoring state: %d live, %d offloaded sessions from pool.json", len(liveSessions), len(offloadedSessions))
@@ -91,7 +96,6 @@ func (m *Manager) handleInit(id any, req api.Msg) api.Msg {
 		s.Status = StatusFresh
 		log.Printf("[init] restoring live session %s (claude=%s resume=%v)", s.ID, s.ClaudeUUID, s.ClaudeUUID != "")
 		m.spawnSession(s, s.ClaudeUUID != "")
-		sessions = append(sessions, s.ToMsg())
 		restored++
 	}
 
@@ -107,7 +111,6 @@ func (m *Manager) handleInit(id any, req api.Msg) api.Msg {
 		s.Status = StatusFresh
 		log.Printf("[init] restoring offloaded session %s (claude=%s resume=%v)", s.ID, s.ClaudeUUID, s.ClaudeUUID != "")
 		m.spawnSession(s, s.ClaudeUUID != "")
-		sessions = append(sessions, s.ToMsg())
 		restored++
 	}
 
@@ -122,19 +125,14 @@ func (m *Manager) handleInit(id any, req api.Msg) api.Msg {
 		s.PreWarmed = true
 		m.sessions[s.ID] = s
 		m.spawnSession(s, false)
-		sessions = append(sessions, s.ToMsg())
 	}
 
-	log.Printf("[init] pool initialized: %d sessions total", len(sessions))
+	log.Printf("[init] pool initialized: %d sessions total", restored+fresh)
 	m.savePoolState()
 	m.startTypingPoller()
 
-	return api.Response(id, "pool", api.Msg{
-		"pool": api.Msg{
-			"size":     float64(size),
-			"sessions": sessions,
-		},
-	})
+	// SPEC: "Pool state after initialization (same as health)."
+	return m.buildHealthResponse(id)
 }
 
 // --- Health ---
@@ -147,6 +145,11 @@ func (m *Manager) handleHealth(id any) api.Msg {
 		return api.ErrorResponse(id, "pool not initialized")
 	}
 
+	return m.buildHealthResponse(id)
+}
+
+// buildHealthResponse builds the health response. Caller must hold m.mu.
+func (m *Manager) buildHealthResponse(id any) api.Msg {
 	counts := map[string]float64{}
 	healthSessions := make([]any, 0)
 
@@ -658,7 +661,7 @@ func (m *Manager) handleInfo(id any, req api.Msg) api.Msg {
 		}
 	}
 
-	msg := s.ToMsgWithChildren(m.sessions)
+	msg := s.ToMsgWithChildren(m.sessions, verbosityFromReq(req, VerbosityFull))
 	return api.Response(id, "session", api.Msg{"session": msg})
 }
 
@@ -669,6 +672,8 @@ func (m *Manager) handleLs(id any, req api.Msg) api.Msg {
 	tree, _ := req["tree"].(bool)
 	showArchived, _ := req["archived"].(bool)
 	callerId, _ := req["callerId"].(string)
+
+	verbosity := verbosityFromReq(req, VerbosityFlat)
 
 	// Parse optional statuses filter
 	var statusFilter map[string]bool
@@ -714,9 +719,9 @@ func (m *Manager) handleLs(id any, req api.Msg) api.Msg {
 					}
 				}
 			}
-			results = append(results, s.ToMsgWithChildren(m.sessions))
+			results = append(results, s.ToMsgWithChildren(m.sessions, verbosity))
 		} else {
-			results = append(results, s.ToMsg())
+			results = append(results, s.ToMsg(verbosity))
 		}
 	}
 

--- a/internal/pool/response_shape_test.go
+++ b/internal/pool/response_shape_test.go
@@ -1,0 +1,183 @@
+package pool
+
+import (
+	"testing"
+	"time"
+
+	"github.com/EliasSchlie/claude-pool/internal/api"
+	"github.com/EliasSchlie/claude-pool/internal/paths"
+	ptyPkg "github.com/EliasSchlie/claude-pool/internal/pty"
+)
+
+// ============================================================
+// Response shape tests
+//
+// Validates that API responses match SPEC.md's contracts:
+// - ToMsg respects verbosity levels (SPEC lines 29-47)
+// - init response = health response is tested in integration
+//   tests (pool_test.go) since handleInit has side effects
+// ============================================================
+
+// --- ToMsg verbosity: flat ---
+
+// Prevents: flat verbosity leaking full-only fields like claudeUUID, parent, cwd, etc.
+func TestToMsgFlatOmitsFullFields(t *testing.T) {
+	s := &Session{
+		ID:         "test123",
+		Status:     StatusIdle,
+		ClaudeUUID: "uuid-abc",
+		ParentID:   "parent-xyz",
+		Cwd:        "/some/path",
+		SpawnCwd:   "/spawn/path",
+		CreatedAt:  time.Now(),
+		PID:        9999,
+		Metadata:   SessionMetadata{Name: "test"},
+	}
+
+	msg := s.ToMsg(VerbosityFlat)
+
+	// flat MUST have sessionId and status
+	if _, ok := msg["sessionId"]; !ok {
+		t.Error("flat: missing sessionId")
+	}
+	if _, ok := msg["status"]; !ok {
+		t.Error("flat: missing status")
+	}
+
+	// flat MUST NOT have full-only fields
+	fullOnlyFields := []string{"claudeUUID", "parent", "cwd", "spawnCwd", "createdAt", "pid", "metadata"}
+	for _, field := range fullOnlyFields {
+		if _, ok := msg[field]; ok {
+			t.Errorf("flat: should not include %q (full-only field)", field)
+		}
+	}
+}
+
+// Prevents: flat verbosity always including priority/pinned/pendingInput
+// instead of only when non-default (SPEC: "✓* = only shown if non-default")
+func TestToMsgFlatConditionalFields(t *testing.T) {
+	t.Run("default values omitted", func(t *testing.T) {
+		s := &Session{
+			ID:       "test123",
+			Status:   StatusIdle,
+			Priority: 0,
+			Pinned:   false,
+		}
+		msg := s.ToMsg(VerbosityFlat)
+
+		if _, ok := msg["priority"]; ok {
+			t.Error("flat: priority=0 (default) should be omitted")
+		}
+		if _, ok := msg["pinned"]; ok {
+			t.Error("flat: pinned=false (default) should be omitted")
+		}
+		if _, ok := msg["pendingInput"]; ok {
+			t.Error("flat: pendingInput should be omitted when session is not live or input is empty")
+		}
+	})
+
+	t.Run("non-default values included", func(t *testing.T) {
+		s := &Session{
+			ID:           "test123",
+			Status:       StatusIdle,
+			Priority:     5,
+			Pinned:       true,
+			PendingInput: "some text",
+		}
+		msg := s.ToMsg(VerbosityFlat)
+
+		if _, ok := msg["priority"]; !ok {
+			t.Error("flat: priority=5 (non-default) should be included")
+		}
+		if _, ok := msg["pinned"]; !ok {
+			t.Error("flat: pinned=true (non-default) should be included")
+		}
+		if _, ok := msg["pendingInput"]; !ok {
+			t.Error("flat: pendingInput with text should be included for live session")
+		}
+	})
+}
+
+// --- ToMsg verbosity: full ---
+
+// Prevents: full verbosity missing fields that the spec requires
+func TestToMsgFullIncludesAllFields(t *testing.T) {
+	s := &Session{
+		ID:         "test123",
+		Status:     StatusIdle,
+		ClaudeUUID: "uuid-abc",
+		ParentID:   "parent-xyz",
+		Cwd:        "/some/path",
+		SpawnCwd:   "/spawn/path",
+		CreatedAt:  time.Now(),
+		PID:        9999,
+		Priority:   0,
+		Pinned:     false,
+		Metadata:   SessionMetadata{Name: "test"},
+	}
+
+	msg := s.ToMsg(VerbosityFull)
+
+	requiredFields := []string{
+		"sessionId", "status", "priority", "pinned",
+		"parent", "cwd", "claudeUUID", "spawnCwd", "createdAt", "pid", "metadata",
+	}
+	for _, field := range requiredFields {
+		if _, ok := msg[field]; !ok {
+			t.Errorf("full: missing required field %q", field)
+		}
+	}
+}
+
+// --- buildHealthResponse does not deadlock when lock is held ---
+
+// Prevents: buildHealthResponse re-acquiring m.mu (which would deadlock
+// when called from handleInit, which already holds the lock).
+func TestBuildHealthResponseWithLockHeld(t *testing.T) {
+	m := newTestManager(t)
+	m.initialized = true
+	m.poolSize = 2
+
+	m.sessions["a"] = &Session{ID: "a", Status: StatusIdle, CreatedAt: time.Now(), PID: 123}
+	m.sessions["b"] = &Session{ID: "b", Status: StatusOffloaded, CreatedAt: time.Now()}
+
+	done := make(chan api.Msg, 1)
+	go func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		done <- m.buildHealthResponse(1)
+	}()
+
+	select {
+	case resp := <-done:
+		health, ok := resp["health"].(api.Msg)
+		if !ok {
+			t.Fatal("missing health object in response")
+		}
+		if numVal(health, "size") != 2 {
+			t.Errorf("expected size 2, got %v", health["size"])
+		}
+		if _, ok := health["counts"]; !ok {
+			t.Error("missing counts")
+		}
+		if _, ok := health["queueDepth"]; !ok {
+			t.Error("missing queueDepth")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("deadlock: buildHealthResponse blocked while lock held")
+	}
+}
+
+// --- helper ---
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	return &Manager{
+		paths:    paths.New(t.TempDir()),
+		sessions: make(map[string]*Session),
+		procs:    make(map[string]*ptyPkg.Process),
+		pidToSID: make(map[int]string),
+		pipes:    make(map[string]*attachPipe),
+		done:     make(chan struct{}),
+	}
+}

--- a/internal/pool/session.go
+++ b/internal/pool/session.go
@@ -79,56 +79,81 @@ func (s *Session) ExternalStatus() string {
 }
 
 // ToMsg converts a session to a protocol message.
-func (s *Session) ToMsg() map[string]any {
+// Verbosity levels for session serialization (SPEC: Session Object table).
+const (
+	VerbosityFlat   = "flat"
+	VerbosityNested = "nested"
+	VerbosityFull   = "full"
+)
+
+// ToMsg converts a session to a protocol message at the given verbosity level.
+//
+// Verbosity controls which fields are included (SPEC lines 29-47):
+//   - flat:   sessionId, status, + priority/pinned/pendingInput only if non-default
+//   - nested: same as flat + children
+//   - full:   all fields always
+func (s *Session) ToMsg(verbosity string) map[string]any {
 	m := map[string]any{
 		"sessionId": s.ID,
 		"status":    s.ExternalStatus(),
-		"priority":  s.Priority,
-		"pinned":    s.Pinned,
-		"createdAt": s.CreatedAt.UTC().Format(time.RFC3339),
 	}
-	if s.ClaudeUUID != "" {
-		m["claudeUUID"] = s.ClaudeUUID
-	}
-	if s.ParentID != "" {
+
+	if verbosity == VerbosityFull {
+		// Full: always include all fields
+		m["priority"] = s.Priority
+		m["pinned"] = s.Pinned
+		if s.IsLive() {
+			m["pendingInput"] = s.PendingInput
+		}
 		m["parent"] = s.ParentID
-	}
-	if s.Cwd != "" {
 		m["cwd"] = s.Cwd
-	}
-	if s.SpawnCwd != "" {
+		if s.ClaudeUUID != "" {
+			m["claudeUUID"] = s.ClaudeUUID
+		} else {
+			m["claudeUUID"] = nil
+		}
 		m["spawnCwd"] = s.SpawnCwd
+		m["createdAt"] = s.CreatedAt.UTC().Format(time.RFC3339)
+		if s.PID != 0 {
+			m["pid"] = float64(s.PID)
+		} else {
+			m["pid"] = nil
+		}
+		meta := map[string]any{}
+		for k, v := range s.Metadata.Tags {
+			meta[k] = v
+		}
+		if s.Metadata.Name != "" {
+			meta["name"] = s.Metadata.Name
+		}
+		if s.Metadata.Description != "" {
+			meta["description"] = s.Metadata.Description
+		}
+		m["metadata"] = meta
+	} else {
+		// Flat/nested: only ✓* fields when non-default
+		if s.Priority != 0 {
+			m["priority"] = s.Priority
+		}
+		if s.Pinned {
+			m["pinned"] = s.Pinned
+		}
+		if s.IsLive() && s.PendingInput != "" {
+			m["pendingInput"] = s.PendingInput
+		}
 	}
-	if s.PID != 0 {
-		m["pid"] = float64(s.PID)
-	}
-	// Always include pendingInput for loaded sessions (empty string = nothing typed)
-	if s.IsLive() {
-		m["pendingInput"] = s.PendingInput
-	}
-	// Metadata: flat key-value pairs (spec: "Arbitrary key-value pairs")
-	// Tags are the primary storage; Name/Description included for backward compat.
-	meta := map[string]any{}
-	for k, v := range s.Metadata.Tags {
-		meta[k] = v
-	}
-	if s.Metadata.Name != "" {
-		meta["name"] = s.Metadata.Name
-	}
-	if s.Metadata.Description != "" {
-		meta["description"] = s.Metadata.Description
-	}
-	m["metadata"] = meta
+
 	return m
 }
 
 // ToMsgWithChildren converts a session to a protocol message with recursive children.
-func (s *Session) ToMsgWithChildren(allSessions map[string]*Session) map[string]any {
-	m := s.ToMsg()
+// Verbosity is applied recursively to all children.
+func (s *Session) ToMsgWithChildren(allSessions map[string]*Session, verbosity string) map[string]any {
+	m := s.ToMsg(verbosity)
 	children := make([]any, 0)
 	for _, other := range allSessions {
 		if other.ParentID == s.ID && other.Status != StatusArchived {
-			children = append(children, other.ToMsgWithChildren(allSessions))
+			children = append(children, other.ToMsgWithChildren(allSessions, verbosity))
 		}
 	}
 	m["children"] = children

--- a/tests/integration/pool_test.go
+++ b/tests/integration/pool_test.go
@@ -13,23 +13,24 @@ package integration
 //   1.  "ping before init fails"
 //   2.  "pools before init"
 //   3.  "init"
-//   4.  "init errors if already running"
-//   5.  "ping after init"
-//   6.  "health"
-//   7.  "pools lists the pool"
-//   8.  "config read"
-//   9.  "config set"
-//   9a. "config keepFresh"
-//  10.  "resize rejects size 0"
-//  11.  "resize up to 3"
-//  12.  "resize down to 1"
-//  13.  "resize reversal clears pending kill tokens"
-//  14.  "deferred eviction of processing sessions"
-//  15.  "resize respects pins"
-//  16.  "destroy without confirm errors"
-//  17.  "destroy"
-//  18.  "re-init restores sessions and config"
-//  19.  "re-init with no-restore"
+//   4.  "init response matches health"
+//   5.  "init errors if already running"
+//   6.  "ping after init"
+//   7.  "health"
+//   8.  "pools lists the pool"
+//   9.  "config read"
+//  10.  "config set"
+//  10a. "config keepFresh"
+//  11.  "resize rejects size 0"
+//  12.  "resize up to 3"
+//  13.  "resize down to 1"
+//  14.  "resize reversal clears pending kill tokens"
+//  15.  "deferred eviction of processing sessions"
+//  16.  "resize respects pins"
+//  17.  "destroy without confirm errors"
+//  18.  "destroy"
+//  19.  "re-init restores sessions and config"
+//  20.  "re-init with no-restore"
 
 import (
 	"testing"
@@ -59,12 +60,13 @@ func TestPool(t *testing.T) {
 			"--keep-fresh", "0",
 			"--flags", "--dangerously-skip-permissions --model haiku")
 
-		poolState, ok := resp["pool"].(map[string]any)
+		// SPEC: init response is "same as health"
+		health, ok := resp["health"].(map[string]any)
 		if !ok {
-			t.Fatalf("expected pool object in init response, got %v", resp)
+			t.Fatalf("expected health object in init response, got %v", resp)
 		}
-		if numVal(poolState, "size") != 2 {
-			t.Fatalf("expected pool size 2, got %v", numVal(poolState, "size"))
+		if numVal(health, "size") != 2 {
+			t.Fatalf("expected pool size 2, got %v", numVal(health, "size"))
 		}
 
 		pool.waitForIdleCount(2, 90*time.Second)
@@ -75,6 +77,26 @@ func TestPool(t *testing.T) {
 		}
 		s1 = sessions[0].SessionID
 		s2 = sessions[1].SessionID
+	})
+
+	// Prevents: init response diverging from health response
+	// (SPEC: "Pool state after initialization (same as health).")
+	t.Run("init response matches health", func(t *testing.T) {
+		health := pool.getHealth()
+
+		// Verify health fields present — same ones we check in the health step
+		if numVal(health, "size") != 2 {
+			t.Fatalf("init health size: expected 2, got %v", numVal(health, "size"))
+		}
+		if _, ok := health["counts"]; !ok {
+			t.Fatal("init health response missing 'counts'")
+		}
+		if _, ok := health["queueDepth"]; !ok {
+			t.Fatal("init health response missing 'queueDepth'")
+		}
+		if _, ok := health["sessions"]; !ok {
+			t.Fatal("init health response missing 'sessions'")
+		}
 	})
 
 	t.Run("init errors if already running", func(t *testing.T) {
@@ -290,12 +312,12 @@ func TestPool(t *testing.T) {
 		pool.awaitSocketGone(10 * time.Second)
 
 		resp := pool.runJSON("init", "--size", "2", "--dir", pool.workDir, "--keep-fresh", "0")
-		poolState, ok := resp["pool"].(map[string]any)
+		health, ok := resp["health"].(map[string]any)
 		if !ok {
-			t.Fatalf("expected pool object in init response")
+			t.Fatalf("expected health object in init response")
 		}
-		if numVal(poolState, "size") != 2 {
-			t.Fatalf("expected size 2, got %v", numVal(poolState, "size"))
+		if numVal(health, "size") != 2 {
+			t.Fatalf("expected size 2, got %v", numVal(health, "size"))
 		}
 
 		pool.waitForIdleCount(2, 90*time.Second)


### PR DESCRIPTION
## Summary

- **init response = health**: `handleInit` now delegates to `buildHealthResponse` (shared lock-free helper) instead of building its own `{type:"pool"}` response. Matches SPEC: "Pool state after initialization (same as health)."
- **ToMsg verbosity**: `ToMsg(verbosity)` and `ToMsgWithChildren` now respect flat/nested/full levels per SPEC Session Object table. `ls` defaults to flat, `info` defaults to full.
- **Deadlock fix**: Extracted `buildHealthResponse` so `handleInit` (which holds `m.mu`) doesn't call `handleHealth` (which also locks `m.mu`).

## Test plan

- [x] Unit tests: `TestToMsgFlatOmitsFullFields`, `TestToMsgFlatConditionalFields`, `TestToMsgFullIncludesAllFields`
- [x] Unit test: `TestBuildHealthResponseWithLockHeld` (deadlock regression)
- [x] Integration test: `TestPool/"init response matches health"` step added
- [x] Integration test: existing init/re-init assertions updated for new response shape
- [ ] Run full integration suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)