### PR TITLE
tests: add assertNumVal helper, deduplicate 25 inline checks

### DIFF
--- a/tests/integration/attach_test.go
+++ b/tests/integration/attach_test.go
@@ -340,12 +340,8 @@ func TestAttach(t *testing.T) {
 		attachResp := sc.send(Msg{"type": "attach", "sessionId": s1})
 		assertNotError(t, attachResp)
 
-		if numVal(attachResp, "cols") != 120 {
-			t.Fatalf("expected cols=120 after resize, got %v", numVal(attachResp, "cols"))
-		}
-		if numVal(attachResp, "rows") != 40 {
-			t.Fatalf("expected rows=40 after resize, got %v", numVal(attachResp, "rows"))
-		}
+		assertNumVal(t, attachResp, "cols", 120)
+		assertNumVal(t, attachResp, "rows", 40)
 
 		// Resize to a different size to confirm it's not a cached value
 		resp2 := sc.send(Msg{"type": "pty-resize", "sessionId": s1, "cols": 200, "rows": 50})
@@ -354,12 +350,8 @@ func TestAttach(t *testing.T) {
 		attachResp2 := sc.send(Msg{"type": "attach", "sessionId": s1})
 		assertNotError(t, attachResp2)
 
-		if numVal(attachResp2, "cols") != 200 {
-			t.Fatalf("expected cols=200 after second resize, got %v", numVal(attachResp2, "cols"))
-		}
-		if numVal(attachResp2, "rows") != 50 {
-			t.Fatalf("expected rows=50 after second resize, got %v", numVal(attachResp2, "rows"))
-		}
+		assertNumVal(t, attachResp2, "cols", 200)
+		assertNumVal(t, attachResp2, "rows", 50)
 	})
 
 	t.Run("pty-resize on non-live session errors", func(t *testing.T) {

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -708,6 +708,14 @@ func assertHasChild(t *testing.T, parent SessionInfo, childID string) {
 	t.Fatalf("expected session %s to have child %s", parent.SessionID, childID)
 }
 
+func assertNumVal(t *testing.T, m Msg, key string, expected float64) {
+	t.Helper()
+	got := numVal(m, key)
+	if got != expected {
+		t.Fatalf("expected %s=%v, got %v", key, expected, got)
+	}
+}
+
 func assertExitError(t *testing.T, result cmdResult) {
 	t.Helper()
 	if result.ExitCode == 0 {

--- a/tests/integration/keep_fresh_test.go
+++ b/tests/integration/keep_fresh_test.go
@@ -43,9 +43,7 @@ func TestKeepFresh(t *testing.T) {
 		// Verify config has keepFresh=1
 		resp := pool.runJSON("config")
 		cfg, _ := resp["config"].(map[string]any)
-		if numVal(cfg, "keepFresh") != 1 {
-			t.Fatalf("expected keepFresh 1, got %v", numVal(cfg, "keepFresh"))
-		}
+		assertNumVal(t, cfg, "keepFresh", 1)
 	})
 
 	t.Run("fresh slots maintained after sessions go idle", func(t *testing.T) {
@@ -152,14 +150,8 @@ func TestKeepFresh(t *testing.T) {
 
 		health := pool.getHealth()
 		counts, _ := health["counts"].(map[string]any)
-		if numVal(counts, "idle") != 3 {
-			t.Fatalf("expected 3 idle sessions with keepFresh=0, got %v (counts: %v)",
-				numVal(counts, "idle"), counts)
-		}
-		if numVal(counts, "fresh") != 0 {
-			t.Fatalf("expected 0 fresh slots with keepFresh=0 and full pool, got %v",
-				numVal(counts, "fresh"))
-		}
+		assertNumVal(t, counts, "idle", 3)
+		assertNumVal(t, counts, "fresh", 0)
 	})
 
 	t.Run("config update triggers fresh slot maintenance", func(t *testing.T) {

--- a/tests/integration/multi_pool_test.go
+++ b/tests/integration/multi_pool_test.go
@@ -161,9 +161,7 @@ func TestMultiPool(t *testing.T) {
 		assertExitOK(t, result)
 
 		health := beta.getHealth()
-		if numVal(health, "size") != 1 {
-			t.Fatalf("expected beta size 1, got %v", numVal(health, "size"))
-		}
+		assertNumVal(t, health, "size", 1)
 
 		info := beta.getSessionInfo(betaSession)
 		assertStatus(t, info, "idle")

--- a/tests/integration/pool_test.go
+++ b/tests/integration/pool_test.go
@@ -65,9 +65,7 @@ func TestPool(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected health object in init response, got %v", resp)
 		}
-		if numVal(health, "size") != 2 {
-			t.Fatalf("expected pool size 2, got %v", numVal(health, "size"))
-		}
+		assertNumVal(t, health, "size", 2)
 
 		pool.waitForIdleCount(2, 90*time.Second)
 
@@ -85,9 +83,7 @@ func TestPool(t *testing.T) {
 		health := pool.getHealth()
 
 		// Verify health fields present — same ones we check in the health step
-		if numVal(health, "size") != 2 {
-			t.Fatalf("init health size: expected 2, got %v", numVal(health, "size"))
-		}
+		assertNumVal(t, health, "size", 2)
 		if _, ok := health["counts"]; !ok {
 			t.Fatal("init health response missing 'counts'")
 		}
@@ -112,16 +108,10 @@ func TestPool(t *testing.T) {
 	t.Run("health", func(t *testing.T) {
 		health := pool.getHealth()
 
-		if numVal(health, "size") != 2 {
-			t.Fatalf("expected size 2, got %v", numVal(health, "size"))
-		}
+		assertNumVal(t, health, "size", 2)
 		counts, _ := health["counts"].(map[string]any)
-		if numVal(counts, "idle") != 2 {
-			t.Fatalf("expected 2 idle, got %v", numVal(counts, "idle"))
-		}
-		if numVal(health, "queueDepth") != 0 {
-			t.Fatalf("expected queue depth 0, got %v", numVal(health, "queueDepth"))
-		}
+		assertNumVal(t, counts, "idle", 2)
+		assertNumVal(t, health, "queueDepth", 0)
 	})
 
 	t.Run("pools lists the pool", func(t *testing.T) {
@@ -138,23 +128,17 @@ func TestPool(t *testing.T) {
 			t.Fatalf("expected config object, got %T", resp["config"])
 		}
 		assertContains(t, strVal(cfg, "flags"), "haiku")
-		if numVal(cfg, "size") != 2 {
-			t.Fatalf("expected size 2, got %v", numVal(cfg, "size"))
-		}
+		assertNumVal(t, cfg, "size", 2)
 	})
 
 	t.Run("config set", func(t *testing.T) {
 		resp := pool.runJSON("config", "--set", "size=4")
 		cfg, _ := resp["config"].(map[string]any)
-		if numVal(cfg, "size") != 4 {
-			t.Fatalf("expected size 4 after set, got %v", numVal(cfg, "size"))
-		}
+		assertNumVal(t, cfg, "size", 4)
 
 		readResp := pool.runJSON("config")
 		readCfg, _ := readResp["config"].(map[string]any)
-		if numVal(readCfg, "size") != 4 {
-			t.Fatalf("config not persisted: expected 4, got %v", numVal(readCfg, "size"))
-		}
+		assertNumVal(t, readCfg, "size", 4)
 
 		pool.run("config", "--set", "size=2")
 	})
@@ -163,23 +147,17 @@ func TestPool(t *testing.T) {
 		// Init used --keep-fresh 0, verify it was persisted
 		resp := pool.runJSON("config")
 		cfg, _ := resp["config"].(map[string]any)
-		if numVal(cfg, "keepFresh") != 0 {
-			t.Fatalf("expected keepFresh 0, got %v", numVal(cfg, "keepFresh"))
-		}
+		assertNumVal(t, cfg, "keepFresh", 0)
 
 		// Set keepFresh via config
 		setResp := pool.runJSON("config", "--set", "keepFresh=2")
 		setCfg, _ := setResp["config"].(map[string]any)
-		if numVal(setCfg, "keepFresh") != 2 {
-			t.Fatalf("expected keepFresh 2 after set, got %v", numVal(setCfg, "keepFresh"))
-		}
+		assertNumVal(t, setCfg, "keepFresh", 2)
 
 		// Verify persistence
 		readResp := pool.runJSON("config")
 		readCfg, _ := readResp["config"].(map[string]any)
-		if numVal(readCfg, "keepFresh") != 2 {
-			t.Fatalf("keepFresh not persisted: expected 2, got %v", numVal(readCfg, "keepFresh"))
-		}
+		assertNumVal(t, readCfg, "keepFresh", 2)
 
 		// Restore to 0
 		pool.run("config", "--set", "keepFresh=0")
@@ -316,9 +294,7 @@ func TestPool(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected health object in init response")
 		}
-		if numVal(health, "size") != 2 {
-			t.Fatalf("expected size 2, got %v", numVal(health, "size"))
-		}
+		assertNumVal(t, health, "size", 2)
 
 		pool.waitForIdleCount(2, 90*time.Second)
 

--- a/tests/integration/slots_test.go
+++ b/tests/integration/slots_test.go
@@ -45,9 +45,7 @@ func TestSlots(t *testing.T) {
 		pool.waitForIdle(s2, 300*time.Second)
 
 		health := pool.getHealth()
-		if numVal(health, "queueDepth") != 0 {
-			t.Fatalf("expected queue depth 0, got %v", numVal(health, "queueDepth"))
-		}
+		assertNumVal(t, health, "queueDepth", 0)
 	})
 
 	var s3 string
@@ -73,9 +71,7 @@ func TestSlots(t *testing.T) {
 		}
 
 		health := pool.getHealth()
-		if numVal(health, "queueDepth") != 1 {
-			t.Fatalf("expected queue depth 1, got %v", numVal(health, "queueDepth"))
-		}
+		assertNumVal(t, health, "queueDepth", 1)
 	})
 
 	t.Run("capture on fresh-queued session errors", func(t *testing.T) {
@@ -99,9 +95,7 @@ func TestSlots(t *testing.T) {
 		assertExitError(t, infoResult)
 
 		health := pool.getHealth()
-		if numVal(health, "queueDepth") != 0 {
-			t.Fatalf("expected queue depth 0, got %v", numVal(health, "queueDepth"))
-		}
+		assertNumVal(t, health, "queueDepth", 0)
 	})
 
 	var s4 string

--- a/tests/integration/subscribe_test.go
+++ b/tests/integration/subscribe_test.go
@@ -284,9 +284,7 @@ func TestSubscribe(t *testing.T) {
 		}
 
 		changes, _ := ev["changes"].(map[string]any)
-		if numVal(changes, "priority") != 5 {
-			t.Fatalf("expected priority 5 in changes, got %v", changes["priority"])
-		}
+		assertNumVal(t, changes, "priority", 5)
 
 		sc.send(Msg{"type": "set", "sessionId": s1, "priority": 0})
 		sub.drain()


### PR DESCRIPTION
## Summary

- Add `assertNumVal(t, map, key, expected)` helper to `helpers_test.go`
- Replace all 25 instances of the 3-line `numVal + if != expected + Fatalf` pattern across 7 test files
- Net -42 lines. Pure mechanical refactor, no logic changes.

## Test plan

- [ ] `go vet ./tests/integration/` passes
- [ ] All existing tests still pass (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)