### PR TITLE
Sync skill with spec: missing flags + debug sub-skill

### DIFF
--- a/skills/claude-pool/SKILL.md
+++ b/skills/claude-pool/SKILL.md
@@ -34,14 +34,18 @@ claude-pool-cli start                             # Start without prompt (idle s
 # Monitor and interact
 claude-pool-cli wait --session <id>               # Wait for session to become idle
 claude-pool-cli wait                              # Wait for any owned session
+claude-pool-cli wait --timeout 60000              # With timeout (default: 300000ms)
 claude-pool-cli capture --session <id>            # Get output immediately
 claude-pool-cli ls                                # List your sessions
+claude-pool-cli ls --status idle,processing       # Filter by state
+claude-pool-cli ls --archived                     # Include archived sessions
 claude-pool-cli ls --verbosity nested             # Show parent-child hierarchy
 claude-pool-cli info --session <id>               # Full session details
 
 # Follow-up and control
-claude-pool-cli followup --session <id> --prompt "prompt"  # Send to idle session
-claude-pool-cli stop --session <id>               # Interrupt processing session
+claude-pool-cli followup --session <id> --prompt "prompt"          # Send to idle session
+claude-pool-cli followup --session <id> --prompt "prompt" --block  # Send + wait for result
+claude-pool-cli stop --session <id>               # Interrupt or cancel queued session
 claude-pool-cli archive --session <id>            # Mark as done
 claude-pool-cli archive --session <id> --recursive  # Archive with descendants
 claude-pool-cli unarchive --session <id>          # Restore archived session
@@ -77,13 +81,9 @@ Commands that return output (`wait`, `capture`, `start --block`, `followup --blo
 | `--turns` | integer | `1` | How many turns back (`0` = all). |
 | `--detail` | `last`, `assistant`, `tools`, `raw` | `last` | What to include per turn (JSONL only). |
 
-## Pool Selection
+## Global Flags
 
-```bash
-claude-pool-cli --pool work start --prompt "..."  # Target a named pool
-claude-pool-cli --pool default ls                  # Default pool
-claude-pool-cli pools                              # List known pools
-```
+All commands accept `--pool <name>` (default: `default`) and `--json` for machine-readable output.
 
 ## Parent-Child Sessions
 
@@ -99,3 +99,7 @@ Sessions spawned from within a pool session automatically track their parent. `l
 | `offloaded` | Saved, not in a slot |
 | `error` | Repeatedly failed to load |
 | `archived` | Done, hidden from `ls` |
+
+## Troubleshooting
+
+For eviction tuning (`set` priority/pin) and debug commands (`debug slots`, `debug logs`, etc.), see [debug.md](debug.md).

--- a/skills/claude-pool/debug.md
+++ b/skills/claude-pool/debug.md
@@ -1,0 +1,25 @@
+# Debug & Advanced Commands
+
+For troubleshooting pool issues or tuning session eviction behavior.
+
+## Session Properties
+
+```bash
+claude-pool-cli set --session <id> --priority 5         # Eviction priority (lower = evicted first, default: 0)
+claude-pool-cli set --session <id> --pinned 3600         # Pin for N seconds (protected from eviction)
+claude-pool-cli set --session <id> --pinned false        # Unpin
+claude-pool-cli set --session <id> --meta env=staging    # Set metadata (repeatable)
+```
+
+## Debug Commands
+
+All under `claude-pool-cli debug <command>`.
+
+```bash
+claude-pool-cli debug slots                              # Show slot states + slot↔session mappings
+claude-pool-cli debug logs                               # Tail daemon log (last 50 lines)
+claude-pool-cli debug logs --lines 200 --follow          # More lines + stream
+claude-pool-cli debug input --session <id> --data "text" # Send raw bytes to PTY (use followup for prompts)
+claude-pool-cli debug capture --slot 0                   # Raw terminal buffer from slot (ANSI stripped)
+claude-pool-cli debug capture --slot 0 --raw             # With ANSI escape codes
+```


### PR DESCRIPTION
## Summary

- **Main skill**: Added `--timeout` on `wait`, `--block` on `followup`, `--status`/`--archived` on `ls`, documented global `--json` flag, consolidated pool selection section into global flags
- **Debug sub-skill**: New `debug.md` covering `set` (priority/pin/metadata) and all `debug` commands (`slots`, `logs`, `input`, `capture`) — per spec's skill section requirements

## Test plan

- [ ] Verify skill loads correctly via `claude --plugin-dir .`
- [ ] Confirm debug sub-skill is reachable from main skill's troubleshooting link

🤖 Generated with [Claude Code](https://claude.com/claude-code)