### PR TITLE
Add go:generate to sync hooks/ → embedded/

### DIFF
--- a/cmd/claude-pool/setup.go
+++ b/cmd/claude-pool/setup.go
@@ -10,6 +10,12 @@ import (
 	"time"
 )
 
+// Sync hook scripts from hooks/ (source of truth) to embedded/ (for go:embed).
+// Run `go generate ./cmd/claude-pool/` after editing hooks/.
+//go:generate cp ../../hooks/hooks.json embedded/hooks.json
+//go:generate cp ../../hooks/hook-runner.sh embedded/hook-runner.sh
+//go:generate cp ../../hooks/pid-registry.sh embedded/pid-registry.sh
+
 //go:embed embedded/skill.md
 var embeddedSkill embed.FS
 

--- a/deploy-plugin.sh
+++ b/deploy-plugin.sh
@@ -5,4 +5,8 @@
 set -euo pipefail
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 cd "$SCRIPT_DIR"
+
+# Sync hook scripts to embedded/ (source of truth is hooks/)
+go generate ./cmd/claude-pool/
+
 go run ./cmd/claude-pool install


### PR DESCRIPTION
## Summary

- `go:generate` directives in `setup.go` copy `hooks/` → `cmd/claude-pool/embedded/` (Go can't embed from parent dirs)
- `deploy-plugin.sh` runs `go generate` automatically before install
- Prevents stale embedded copies when adding/modifying hook scripts

Previously these copies were manual — we hit this when adding `pid-registry.sh` in #73.

The local marketplace auto-update issue (#73 debugging) was caused by developing in a worktree while the marketplace symlink points to main. Not a code issue — resolved by merging to main.

## Test plan

- [x] `go generate ./cmd/claude-pool/` works
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)