### PR TITLE
Replace hook-based idle detection with screen content monitoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,5 @@
   "license": "MIT",
   "name": "claude-pool",
   "repository": "https://github.com/EliasSchlie/claude-pool",
-  "version": "0.1.3"
+  "version": "0.1.25"
 }

--- a/cmd/claude-pool/embedded/hooks.json
+++ b/cmd/claude-pool/embedded/hooks.json
@@ -23,17 +23,6 @@
         ]
       }
     ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.sh idle-signal.sh write stop",
-            "async": true
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -41,45 +30,6 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pid-registry.sh"
-          }
-        ]
-      },
-      {
-        "matcher": "AskUserQuestion|ExitPlanMode",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.sh idle-signal.sh write tool"
-          }
-        ]
-      }
-    ],
-    "PermissionRequest": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.sh idle-signal.sh write permission"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.sh idle-signal.sh clear"
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.sh idle-signal.sh clear"
           }
         ]
       }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,7 @@ Hooks tell the pool daemon when sessions change state (idle, processing, etc.). 
 ### Global install (`claude-pool install`)
 
 - Writes `~/.claude-pool/hook-runner.sh` — a thin entry point that delegates to pool-local scripts
-- Registers hook entries in `~/.claude/settings.json` for all relevant events (SessionStart, Stop, PreToolUse, PermissionRequest, PostToolUse, UserPromptSubmit)
+- Registers hook entries in `~/.claude/settings.json` for all relevant events (SessionStart, PreToolUse, PermissionRequest, PostToolUse, UserPromptSubmit)
 - Installs the Claude Code skill to `~/.claude/skills/claude-pool/SKILL.md`
 - Run once per machine. `claude-pool uninstall` reverses everything.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -23,17 +23,6 @@
         ]
       }
     ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.sh idle-signal.sh write stop",
-            "async": true
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -41,45 +30,6 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pid-registry.sh"
-          }
-        ]
-      },
-      {
-        "matcher": "AskUserQuestion|ExitPlanMode",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.sh idle-signal.sh write tool"
-          }
-        ]
-      }
-    ],
-    "PermissionRequest": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.sh idle-signal.sh write permission"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.sh idle-signal.sh clear"
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.sh idle-signal.sh clear"
           }
         ]
       }

--- a/internal/hookfiles/idle-signal.sh
+++ b/internal/hookfiles/idle-signal.sh
@@ -1,26 +1,18 @@
 #!/bin/bash
-# Signals when a Claude session becomes idle or starts processing.
+# Writes idle signal files for session lifecycle events.
 #
-# IMPORTANT: Idle signals must have NO FALSE POSITIVES. The "stop" trigger
-# defers writing for IDLE_VERIFY_DELAY seconds and verifies the transcript
-# size hasn't changed.
+# Processing state transitions (idle↔processing) are handled entirely by
+# the daemon's screen content monitoring — no hooks needed. This script
+# only handles startup/lifecycle signals.
 #
-# Usage: idle-signal.sh write [stop|tool|permission|session-clear]
-#        idle-signal.sh clear
+# Usage: idle-signal.sh write [session-start|session-clear]
 
 source "$(dirname "$0")/common.sh"
 
-SYSTEM_ENTRY_WAIT=4
-IDLE_VERIFY_DELAY=3
 mkdir -p "$SIGNAL_DIR"
 
 claude_pid="$PPID"
 signal_file="$SIGNAL_DIR/$claude_pid"
-
-# Cross-platform file size in bytes
-file_size() {
-    stat -f %z "$1" 2>/dev/null || stat -c %s "$1" 2>/dev/null || echo 0
-}
 
 # Read hook input from stdin
 read_input() {
@@ -32,79 +24,32 @@ read_input() {
     fi
 }
 
-case "${1:-}" in
-    write)
-        trigger="${2:-unknown}"
-        input=$(read_input)
-        session_id=""
-        transcript=""
-        hook_cwd=""
-        if [ -n "$input" ]; then
-            session_id=$(json_get "$input" "session_id")
-            transcript=$(json_get "$input" "transcript_path")
-            hook_cwd=$(json_get "$input" "cwd")
-        fi
+trigger="${2:-unknown}"
+input=$(read_input)
+session_id=""
+transcript=""
+hook_cwd=""
+if [ -n "$input" ]; then
+    session_id=$(json_get "$input" "session_id")
+    transcript=$(json_get "$input" "transcript_path")
+    hook_cwd=$(json_get "$input" "cwd")
+fi
 
-        json_esc() {
-            printf '%s' "$1" | awk '
-                BEGIN { ORS="" }
-                {
-                    if (NR > 1) printf "\\n"
-                    gsub(/\\/, "\\\\")
-                    gsub(/"/, "\\\"")
-                    gsub(/\t/, "\\t")
-                    gsub(/\r/, "\\r")
-                    printf "%s", $0
-                }
-            '
+json_esc() {
+    printf '%s' "$1" | awk '
+        BEGIN { ORS="" }
+        {
+            if (NR > 1) printf "\\n"
+            gsub(/\\/, "\\\\")
+            gsub(/"/, "\\\"")
+            gsub(/\t/, "\\t")
+            gsub(/\r/, "\\r")
+            printf "%s", $0
         }
+    '
+}
 
-        # Prefer hook-reported cwd (tracks Bash tool cd), fall back to process cwd
-        effective_cwd="${hook_cwd:-$(pwd)}"
-        signal_json=$(printf '{"cwd":"%s","session_id":"%s","transcript":"%s","ts":%d,"trigger":"%s"}\n' \
-            "$(json_esc "$effective_cwd")" "$(json_esc "$session_id")" "$(json_esc "$transcript")" "$(date +%s)" "$(json_esc "$trigger")")
-
-        if [ "$trigger" = "stop" ]; then
-            pending="$signal_file.pending"
-            echo "$$" > "$pending"
-
-            (
-                trap 'rm -f "$pending"' EXIT
-                sleep "$SYSTEM_ENTRY_WAIT"
-
-                [ ! -f "$pending" ] && exit 0
-                [ "$(cat "$pending" 2>/dev/null)" != "$$" ] && exit 0
-
-                before=""
-                if [ -n "$transcript" ] && [ -f "$transcript" ]; then
-                    before=$(file_size "$transcript")
-                fi
-
-                sleep "$IDLE_VERIFY_DELAY"
-
-                [ ! -f "$pending" ] && exit 0
-                [ "$(cat "$pending" 2>/dev/null)" != "$$" ] && exit 0
-
-                if [ -n "$before" ] && [ -f "$transcript" ]; then
-                    after=$(file_size "$transcript")
-                    [ "$before" != "$after" ] && exit 0
-                fi
-
-                if [ "$(cat "$pending" 2>/dev/null)" = "$$" ]; then
-                    printf '%s\n' "$signal_json" > "$signal_file"
-                fi
-            ) &
-            disown
-        else
-            rm -f "$signal_file.pending"
-            printf '%s\n' "$signal_json" > "$signal_file"
-        fi
-        ;;
-    clear)
-        rm -f "$signal_file"
-        # NOTE: Do NOT remove $signal_file.pending here. The "stop" trigger's
-        # background verification process uses it as a coordination file. If
-        # PostToolUse fires between Stop and the verification completing, clearing
-        # .pending would prevent the idle signal from ever being written.
-        ;;
-esac
+effective_cwd="${hook_cwd:-$(pwd)}"
+printf '{"cwd":"%s","session_id":"%s","transcript":"%s","ts":%d,"trigger":"%s"}\n' \
+    "$(json_esc "$effective_cwd")" "$(json_esc "$session_id")" "$(json_esc "$transcript")" "$(date +%s)" "$(json_esc "$trigger")" \
+    > "$signal_file"

--- a/internal/pool/handlers.go
+++ b/internal/pool/handlers.go
@@ -659,10 +659,8 @@ func (m *Manager) handleStop(id any, req api.Msg) api.Msg {
 		sid := s.ID
 		m.mu.Unlock()
 
-		// Ctrl-C → wait for idle. The Stop hook fires asynchronously but
-		// its deferred signal may not arrive if the transcript size changes
-		// during interruption processing. stopProcessingSession handles
-		// the full wait with a timeout fallback.
+		// Ctrl-C → wait for idle. PTY silence detection will write the
+		// idle signal once the spinner stops (~3s).
 		m.stopProcessingSession(sid, 30*time.Second)
 		return api.OkResponse(id)
 

--- a/internal/pool/lifecycle.go
+++ b/internal/pool/lifecycle.go
@@ -193,9 +193,8 @@ func (m *Manager) offloadSessionLocked(s *Session) {
 		log.Printf("[offload] session %s: recycled pid %d into pre-warmed session %s", s.ID, proc.PID(), pw.ID)
 
 		// Clear stale idle signals before starting watchers — the old
-		// session's signals (stop, stop-fallback) must not trigger prompt
-		// delivery in the new session. /clear will produce a fresh
-		// session-clear signal when it completes.
+		// session's signals must not trigger prompt delivery in the new
+		// session. /clear will produce a fresh session-clear signal.
 		m.clearIdleSignals(proc.PID())
 		m.deliverPromptWithSettle(pw, "/clear", 200*time.Millisecond)
 		m.startWatchers(pw, proc)
@@ -340,7 +339,6 @@ func (m *Manager) watchIdleSignal(sessionID string, pid int) {
 	signalPath := m.paths.IdleSignal(pid)
 	pidMapPath := m.paths.SessionPID(pid)
 	var lastSignalTS float64 // timestamp of last processed signal (avoid re-processing)
-	signalPresent := false   // whether signal file existed on previous tick
 
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
@@ -374,32 +372,17 @@ func (m *Manager) watchIdleSignal(sessionID string, pid int) {
 				}
 			}
 
-			// Read signal file under the mutex to prevent races with
-			// clearIdleSignals. Like OC, the daemon never deletes the signal
-			// file — only hooks (idle-signal.sh clear, UserPromptSubmit) do.
-			// Signal presence = idle, signal absence = processing.
+			// Read signal file. Only SessionStart hooks write signals now;
+			// processing↔idle detection is handled by content monitoring.
 			m.mu.Lock()
 			data, err := os.ReadFile(signalPath)
 			if err != nil {
-				// No signal file. If it was present before, a hook cleared
-				// it (UserPromptSubmit or PostToolUse) → processing started.
-				// This handles attach-pipe Enter, external prompt submission,
-				// and any other path where the pool didn't explicitly set
-				// processing status.
-				if signalPresent {
-					signalPresent = false
-					s = m.sessions[sessionID]
-					if s != nil && s.Status == StatusIdle {
-						log.Printf("[idle-watch] session %s: signal cleared (idle→processing)", sessionID)
-						s.Status = StatusProcessing
-						s.PendingInput = ""
-						m.broadcastStatus(s, StatusIdle)
-					}
-				}
+				// No signal file — cleared by clearIdleSignals during recycling
+				// or externally. Idle→processing detection is handled by the
+				// spinner check in pollBufferInput, not here.
 				m.mu.Unlock()
 				continue
 			}
-			signalPresent = true
 
 			// Check session still exists, is live, AND still owns this PID.
 			// If the session was transferred to a different PID (offloaded →
@@ -446,105 +429,75 @@ func (m *Manager) watchIdleSignal(sessionID string, pid int) {
 				}
 			}
 
-			// Filter stale signals that belong to a previous session on this slot.
-			//
-			// Recycled fresh slots (went through /clear) are waiting for the
-			// session-start or session-clear signal that fires when /clear
-			// completes. Other triggers (stop, tool, permission) are stale
-			// leftovers from the previous session and must be ignored —
-			// delivering a prompt during /clear loses it.
-			//
-			// Non-recycled fresh slots already completed startup — any signal
-			// is valid (typically "session-start" from the initial spawn, but
-			// could be "stop" if the process completed something internally).
-			//
-			// Processing slots ignore startup signals unless they have pending
-			// work (PendingResume/PendingPrompt), which means the signal is from
-			// /resume or /clear completing.
+			// watchIdleSignal only handles startup signals (session-start,
+			// session-clear). Processing→idle is handled by content monitoring
+			// in pollBufferInput, which calls transitionToIdle directly.
 			trigger, _ := sig["trigger"].(string)
-			if s.Status == StatusFresh && s.Recycled && trigger != "session-start" && trigger != "session-clear" {
-				log.Printf("[idle-watch] session %s: ignoring stale %s signal (status=fresh+recycled, waiting for clear)", sessionID, trigger)
-				m.mu.Unlock()
-				continue
-			}
-			if s.Status == StatusProcessing && (trigger == "session-start" || trigger == "session-clear") &&
-				s.PendingResume == "" && s.PendingPrompt == "" {
-				log.Printf("[idle-watch] session %s: ignoring stale %s signal (status=%s)", sessionID, trigger, s.Status)
+			if trigger != "session-start" && trigger != "session-clear" {
 				m.mu.Unlock()
 				continue
 			}
 
 			if s.Status == StatusFresh || s.Status == StatusProcessing {
-				// Use a longer settle delay after session-start/session-clear
-				// triggers — Claude's TUI needs time to finish rendering its
-				// startup/clear output before it can accept typed input.
-				settleDelay := 200 * time.Millisecond
-				if trigger == "session-start" || trigger == "session-clear" {
-					settleDelay = 2 * time.Second
-				}
-
-				// Stage 1: deliver /resume if pending (before any prompt).
-				// After /resume completes, another idle signal fires and we
-				// proceed to PendingPrompt delivery.
-				if s.PendingResume != "" {
-					uuid := s.PendingResume
-					s.PendingResume = ""
-					prevStatus := s.Status
-					s.Status = StatusProcessing
-					log.Printf("[idle-watch] session %s: delivering /resume %s", sessionID, uuid)
-					m.broadcastStatus(s, prevStatus)
-					m.deliverPromptWithSettle(s, "/resume "+uuid, settleDelay)
-					m.mu.Unlock()
-					continue
-				}
-
-				// Stage 2: deliver any pending prompt — avoids a transient
-				// idle state that confuses wait-without-sessionId.
-				if s.PendingPrompt != "" {
-					prompt := s.PendingPrompt
-					prevStatus := s.Status
-					s.PendingPrompt = ""
-					s.PendingForce = false
-					s.Status = StatusProcessing
-					s.LastUsedAt = time.Now()
-					log.Printf("[idle-watch] session %s: idle signal received, delivering pending prompt (%d chars)", sessionID, len(prompt))
-					m.broadcastStatus(s, prevStatus)
-					// Register delivery under the lock so awaitDelivery
-					// can't miss it between unlock and goroutine start.
-					m.deliverPromptWithSettle(s, prompt, settleDelay)
-					m.mu.Unlock()
-					continue
-				}
-
-				prevStatus := s.Status
-				s.Status = StatusIdle
-				s.Recycled = false
-				log.Printf("[idle-watch] session %s: %s → idle (pid=%d)", sessionID, prevStatus, s.PID)
-				m.broadcastStatus(s, prevStatus)
-				m.savePoolState()
-
-				// Check if a queued session can claim this slot
-				m.serveQueueFromSlot(s)
-
-				// If queue still has entries, try to free a slot via eviction.
-				// This handles the case where a queued session was waiting for
-				// a slot being /cleared — now that it's idle, it's evictable.
-				if len(m.queue) > 0 {
-					if evicted := m.findEvictableSession(); evicted != nil {
-						log.Printf("[idle-watch] session %s: evicting %s to serve queue (depth=%d)", sessionID, evicted.ID, len(m.queue))
-						m.offloadSessionLocked(evicted)
-						m.tryDequeue()
-					}
-				}
-
-				// Maintain fresh slot target (SPEC: Fresh Slot Maintenance)
-				m.maintainFreshSlots()
-			} else {
-				log.Printf("[idle-watch] session %s: consumed stale signal (status=%s)", sessionID, s.Status)
+				m.transitionToIdle(s)
 			}
 			m.mu.Unlock()
 		}
 	}
+}
+
+// transitionToIdle handles the processing → idle transition for a session.
+// Delivers pending prompts, serves the queue, and maintains fresh slots.
+// Must be called with m.mu held. May release and re-acquire the lock
+// for prompt delivery.
+func (m *Manager) transitionToIdle(s *Session) {
+	// Deliver pending resume first
+	if s.PendingResume != "" {
+		uuid := s.PendingResume
+		s.PendingResume = ""
+		prevStatus := s.Status
+		s.Status = StatusProcessing
+
+		log.Printf("[idle] session %s: delivering /resume %s", s.ID, uuid)
+		m.broadcastStatus(s, prevStatus)
+		m.deliverPromptWithSettle(s, "/resume "+uuid, 200*time.Millisecond)
+		return
+	}
+
+	// Deliver pending prompt
+	if s.PendingPrompt != "" {
+		prompt := s.PendingPrompt
+		prevStatus := s.Status
+		s.PendingPrompt = ""
+		s.PendingForce = false
+		s.Status = StatusProcessing
+
+		s.LastUsedAt = time.Now()
+		log.Printf("[idle] session %s: delivering pending prompt (%d chars)", s.ID, len(prompt))
+		m.broadcastStatus(s, prevStatus)
+		m.deliverPromptWithSettle(s, prompt, 200*time.Millisecond)
+		return
+	}
+
+	// No pending work — mark idle
+	prevStatus := s.Status
+	s.Status = StatusIdle
+	s.Recycled = false
+	log.Printf("[idle] session %s: %s → idle (pid=%d)", s.ID, prevStatus, s.PID)
+	m.broadcastStatus(s, prevStatus)
+	m.savePoolState()
+
+	m.serveQueueFromSlot(s)
+
+	if len(m.queue) > 0 {
+		if evicted := m.findEvictableSession(); evicted != nil {
+			log.Printf("[idle] session %s: evicting %s to serve queue (depth=%d)", s.ID, evicted.ID, len(m.queue))
+			m.offloadSessionLocked(evicted)
+			m.tryDequeue()
+		}
+	}
+
+	m.maintainFreshSlots()
 }
 
 // --- Prompt delivery ---
@@ -672,9 +625,7 @@ func (m *Manager) deliverPromptAsync(sessionID, prompt string) {
 // Used by handleStop, handleArchive, and handleFollowup (force) to stop a
 // processing session before further action. Must be called WITHOUT m.mu held.
 //
-// The Stop hook writes an idle signal with a ~7s deferred verification.
-// If the signal doesn't arrive (transcript size changed during interruption
-// processing), a synthetic signal is written as fallback.
+// PTY silence detection (3s) will write the idle signal once the spinner stops.
 func (m *Manager) stopProcessingSession(sid string, timeout time.Duration) {
 	m.awaitDelivery(sid)
 
@@ -685,31 +636,12 @@ func (m *Manager) stopProcessingSession(sid string, timeout time.Duration) {
 	if s := m.sessions[sid]; s != nil {
 		s.ClearPending()
 	}
-	pid := 0
 	if proc := m.procs[sid]; proc != nil {
 		proc.WriteString("\x03")
-		pid = proc.PID()
 	}
 	m.mu.Unlock()
 
-	// Wait for idle (Stop hook's deferred signal, ~7s).
-	// Use a shorter initial wait, then fall back to synthetic signal.
-	m.waitForSessionIdle(sid, 15*time.Second)
-
-	// If still not idle, write a synthetic signal as fallback.
-	// The Stop hook's transcript-size verification can fail if Claude
-	// wrote output after the Ctrl-C interruption.
-	m.mu.Lock()
-	s := m.sessions[sid]
-	if s != nil && s.Status == StatusProcessing && pid > 0 {
-		log.Printf("[stop] session %s: Stop hook signal not received after 15s, writing synthetic idle signal (pid=%d)", sid, pid)
-		m.mu.Unlock()
-		m.writeIdleSignal(pid, "stop-fallback")
-		// Wait for watchIdleSignal to consume the synthetic signal
-		m.waitForSessionIdle(sid, timeout-15*time.Second)
-	} else {
-		m.mu.Unlock()
-	}
+	m.waitForSessionIdle(sid, timeout)
 }
 
 // waitForSessionIdle waits until a session reaches StatusIdle.
@@ -769,24 +701,6 @@ func (m *Manager) waitForSessionReady(id any, sid string, timeout time.Duration)
 		case <-ch:
 			m.mu.Lock()
 		}
-	}
-}
-
-// writeIdleSignal writes a synthetic idle signal for cases where no hook fires
-// (e.g., after Ctrl-C when the Stop hook's transcript verification fails).
-func (m *Manager) writeIdleSignal(pid int, trigger string) {
-	signalPath := m.paths.IdleSignal(pid)
-	signal := map[string]any{
-		"cwd":        m.paths.Root,
-		"session_id": "",
-		"transcript": "",
-		"ts":         time.Now().Unix(),
-		"trigger":    trigger,
-	}
-	data, _ := json.Marshal(signal)
-	log.Printf("[idle-signal] writing synthetic idle signal for pid %d (trigger=%s)", pid, trigger)
-	if err := os.WriteFile(signalPath, append(data, '\n'), 0600); err != nil {
-		log.Printf("[idle-signal] error writing signal for pid %d: %v", pid, err)
 	}
 }
 
@@ -976,8 +890,6 @@ func (m *Manager) startWatchers(s *Session, proc *ptyPkg.Process) {
 
 // clearIdleSignals removes stale idle signal files for a PID. Called before
 // starting watchers for a transferred process to prevent immediate false triggers.
-// Does NOT remove .pending files — those are coordination files for the Stop
-// hook's background verification process (see idle-signal.sh).
 func (m *Manager) clearIdleSignals(pid int) {
 	os.Remove(m.paths.IdleSignal(pid))
 }

--- a/internal/pool/typing.go
+++ b/internal/pool/typing.go
@@ -31,10 +31,16 @@ func containsBoxDrawing(s string) bool {
 // Re-rendering the full buffer from scratch each poll causes vt10x to
 // produce wrong output for complex cursor sequences.
 type sessionTerm struct {
-	mu   sync.Mutex
-	term vt10x.Terminal
-	sub  chan []byte
-	done chan struct{}
+	mu             sync.Mutex
+	term           vt10x.Terminal
+	sub            chan []byte
+	done           chan struct{}
+	lastOutputTime time.Time // updated on every PTY data chunk
+
+	// Screen change tracking for idle detection. Updated by pollBufferInput.
+	lastContentAbovePrompt string
+	contentChangedAt       time.Time
+	lastIdleTransitionAt   time.Time // prevents duplicate idle transitions for same stable period
 }
 
 // newSessionTerm creates a persistent terminal emulator for a session's process.
@@ -69,6 +75,7 @@ func newSessionTerm(proc *ptyPkg.Process, cols, rows int) *sessionTerm {
 				}
 				st.mu.Lock()
 				st.term.Write(data)
+				st.lastOutputTime = time.Now()
 				st.mu.Unlock()
 			case <-st.done:
 				return
@@ -84,6 +91,16 @@ func (st *sessionTerm) renderedScreen() string {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 	return st.term.String()
+}
+
+// outputSilentFor returns how long since the last PTY output was received.
+func (st *sessionTerm) outputSilentFor() time.Duration {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.lastOutputTime.IsZero() {
+		return 0
+	}
+	return time.Since(st.lastOutputTime)
 }
 
 // stop unsubscribes from PTY output and stops the feed goroutine.
@@ -169,51 +186,113 @@ func (m *Manager) typingPollLoop() {
 	}
 }
 
-type sessionCheck struct {
+type sessionPoll struct {
 	id       string
 	rendered string
 }
 
 func (m *Manager) pollBufferInput() {
 	m.mu.Lock()
-	var toCheck []sessionCheck
+	var toPoll []sessionPoll
 	for id, s := range m.sessions {
-		// Only poll idle sessions — fresh sessions have startup artifacts
-		// (trust dialog, etc.) that cause false positives.
-		if s.Status != StatusIdle {
+		if s.Status != StatusIdle && s.Status != StatusProcessing {
 			continue
 		}
 		st := m.terms[id]
 		if st == nil {
 			continue
 		}
-		toCheck = append(toCheck, sessionCheck{id: id, rendered: st.renderedScreen()})
+		toPoll = append(toPoll, sessionPoll{id: id, rendered: st.renderedScreen()})
 	}
 	m.mu.Unlock()
 
-	for _, item := range toCheck {
+	const idleThreshold = 3 * time.Second
+
+	for _, item := range toPoll {
+		content := contentAbovePrompt(item.rendered)
 		input := parseRenderedInput(item.rendered)
 
 		m.mu.Lock()
 		s := m.sessions[item.id]
-		if s == nil || s.Status != StatusIdle {
+		st := m.terms[item.id]
+		if s == nil || st == nil {
 			m.mu.Unlock()
 			continue
 		}
-		if s.PendingInput != input {
-			prev := s.PendingInput
-			s.PendingInput = input
-			if input != "" || prev != "" {
-				s.LastUsedAt = time.Now()
+
+		// Track whether the content area changed since last poll
+		now := time.Now()
+		if content != st.lastContentAbovePrompt {
+			st.lastContentAbovePrompt = content
+			st.contentChangedAt = now
+		}
+
+		contentStable := !st.contentChangedAt.IsZero() && now.Sub(st.contentChangedAt) >= idleThreshold
+
+		if s.Status == StatusIdle {
+			// Content changing → processing started
+			if !contentStable && !st.contentChangedAt.IsZero() {
+				log.Printf("[typing] session %s: content changing (idle→processing)", s.ID)
+				s.Status = StatusProcessing
+				s.PendingInput = ""
+				m.broadcastStatus(s, StatusIdle)
+				m.mu.Unlock()
+				continue
 			}
-			log.Printf("[typing] session %s: pendingInput %q → %q (buffer poll)", item.id, prev, input)
-			m.broadcastEvent(api.Msg{
-				"type": "event", "event": "updated",
-				"sessionId": s.ID, "changes": api.Msg{"pendingInput": s.PendingInput},
-			})
+
+			// Pending input detection
+			if s.PendingInput != input {
+				prev := s.PendingInput
+				s.PendingInput = input
+				if input != "" || prev != "" {
+					s.LastUsedAt = time.Now()
+				}
+				log.Printf("[typing] session %s: pendingInput %q → %q", item.id, prev, input)
+				m.broadcastEvent(api.Msg{
+					"type": "event", "event": "updated",
+					"sessionId": s.ID, "changes": api.Msg{"pendingInput": s.PendingInput},
+				})
+			}
+		} else if s.Status == StatusProcessing {
+			// Content stable for 3s OR PTY silent for 3s → idle.
+			// Content comparison is the primary signal. PTY silence is the
+			// fallback for when processing produces no visible output change
+			// (e.g., no-op response, output only in prompt area).
+			ptySilent := st.outputSilentFor() >= idleThreshold
+			shouldTransition := (contentStable || ptySilent) && st.lastIdleTransitionAt != st.contentChangedAt
+
+			if shouldTransition {
+				st.lastIdleTransitionAt = st.contentChangedAt
+				reason := "content stable"
+				if !contentStable {
+					reason = "PTY silent"
+				}
+				log.Printf("[typing] session %s: %s for %s (processing→idle)", s.ID, reason, now.Sub(st.contentChangedAt).Round(time.Second))
+				m.transitionToIdle(s)
+			}
 		}
 		m.mu.Unlock()
 	}
+}
+
+// contentAbovePrompt returns the screen content above the first ───
+// separator line (Claude Code's TUI divider above the prompt area).
+// Changes in this area indicate processing; user typing only affects
+// the prompt area below.
+func contentAbovePrompt(rendered string) string {
+	lines := strings.Split(rendered, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if containsBoxDrawing(lines[i]) {
+			// Find the upper separator (there are two — skip the lower one)
+			for j := i - 1; j >= 0; j-- {
+				if containsBoxDrawing(lines[j]) {
+					return strings.Join(lines[:j], "\n")
+				}
+			}
+			return strings.Join(lines[:i], "\n")
+		}
+	}
+	return rendered
 }
 
 // startSessionTerm creates and registers a persistent terminal emulator


### PR DESCRIPTION
## Summary
Replace 5 hooks (Stop, PostToolUse, UserPromptSubmit, PreToolUse tool, PermissionRequest) with screen content monitoring for processing state detection:

- **Content above prompt changing** → processing (replaces hook-based signal clearing)
- **Content stable for 3s** → idle (replaces Stop hook + signal writing)
- **PTY silent for 3s** → idle fallback (catches no-output edge cases)

Content monitoring calls `transitionToIdle()` directly instead of writing signal files, eliminating the race between two parallel state managers that caused rapid idle↔processing flipping.

## Why
- Stop hook didn't fire on Escape/interrupt or after API overload errors → sessions stuck processing forever
- Hook-based signal clearing (PostToolUse/UserPromptSubmit) conflicted with content monitoring → rapid state flipping
- 7-second deferred verification delay in Stop hook was unnecessarily slow

## What remains
- **SessionStart hooks** — fresh/recycled session lifecycle (can't be replaced by content monitoring)
- **PreToolUse Bash** — PID registry for parent-child tracking

## Net change: -166 lines

## Test plan
- [x] Normal prompt → idle
- [x] Back-to-back prompts
- [x] Escape during processing → idle after 3s
- [x] Stop command on processing session
- [x] Queue serving (queued session served after idle)
- [x] No idle↔processing flipping in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)