### PR TITLE
Fix spec violations: never expose internal StatusFresh in API

### DIFF
--- a/internal/pool/handlers.go
+++ b/internal/pool/handlers.go
@@ -199,24 +199,8 @@ func (m *Manager) buildHealthResponse(id any) api.Msg {
 		sessions[s.ExternalStatus()]++
 
 		// Count slot states (only live sessions occupy slots)
-		if !s.IsLive() {
-			continue
-		}
-		switch {
-		case s.PreWarmed && s.Status == StatusFresh && s.Recycled:
-			slots["clearing"]++
-		case s.PreWarmed && s.Status == StatusFresh:
-			slots["spawning"]++
-		case s.PreWarmed && s.Status == StatusIdle:
-			slots["fresh"]++
-		case s.Status == StatusFresh && s.PendingResume != "":
-			slots["resuming"]++
-		case s.Status == StatusFresh:
-			slots["clearing"]++
-		case s.Status == StatusIdle:
-			slots["idle"]++
-		case s.Status == StatusProcessing:
-			slots["processing"]++
+		if slotState := s.SlotState(); slotState != "" {
+			slots[slotState]++
 		}
 	}
 
@@ -295,13 +279,13 @@ func (m *Manager) handleStart(id any, req api.Msg) api.Msg {
 		m.startWatchers(s, proc)
 		m.broadcastEvent(api.Msg{
 			"type": "event", "event": "created",
-			"sessionId": s.ID, "status": StatusProcessing, "parent": s.ParentID,
+			"sessionId": s.ID, "status": s.ExternalStatus(), "parent": s.ParentID,
 		})
 		m.savePoolState()
 		m.mu.Unlock()
 		return api.Response(id, "started", api.Msg{
 			"sessionId": s.ID,
-			"status":    StatusProcessing,
+			"status":    s.ExternalStatus(),
 		})
 	}
 
@@ -312,7 +296,7 @@ func (m *Manager) handleStart(id any, req api.Msg) api.Msg {
 	m.queue = append(m.queue, s)
 	m.broadcastEvent(api.Msg{
 		"type": "event", "event": "created",
-		"sessionId": s.ID, "status": s.Status, "parent": s.ParentID,
+		"sessionId": s.ID, "status": s.ExternalStatus(), "parent": s.ParentID,
 	})
 
 	m.tryDequeueWithEviction(s, "")
@@ -367,7 +351,7 @@ func (m *Manager) handleStartPromptless(id any, s *Session) api.Msg {
 	m.queue = append(m.queue, s)
 	m.broadcastEvent(api.Msg{
 		"type": "event", "event": "created",
-		"sessionId": s.ID, "status": s.Status, "parent": s.ParentID,
+		"sessionId": s.ID, "status": s.ExternalStatus(), "parent": s.ParentID,
 	})
 	m.tryDequeueWithEviction(s, "")
 	m.savePoolState()
@@ -428,7 +412,7 @@ func (m *Manager) handleFollowup(id any, req api.Msg) api.Msg {
 		m.mu.Unlock()
 		return api.Response(id, "started", api.Msg{
 			"sessionId": s.ID,
-			"status":    s.Status,
+			"status":    s.ExternalStatus(),
 		})
 
 	case StatusOffloaded, StatusError:
@@ -443,7 +427,7 @@ func (m *Manager) handleFollowup(id any, req api.Msg) api.Msg {
 		m.mu.Unlock()
 		return api.Response(id, "started", api.Msg{
 			"sessionId": s.ID,
-			"status":    s.Status,
+			"status":    s.ExternalStatus(),
 		})
 
 	case StatusProcessing:
@@ -486,7 +470,7 @@ func (m *Manager) handleFollowup(id any, req api.Msg) api.Msg {
 		m.mu.Unlock()
 		return api.Response(id, "started", api.Msg{
 			"sessionId": s.ID,
-			"status":    s.Status,
+			"status":    s.ExternalStatus(),
 		})
 
 	case StatusArchived:
@@ -495,7 +479,7 @@ func (m *Manager) handleFollowup(id any, req api.Msg) api.Msg {
 
 	default:
 		m.mu.Unlock()
-		return api.ErrorResponse(id, "cannot followup in state: "+s.Status)
+		return api.ErrorResponse(id, "cannot followup in state: "+s.ExternalStatus())
 	}
 }
 
@@ -666,7 +650,7 @@ func (m *Manager) handleStop(id any, req api.Msg) api.Msg {
 
 	default:
 		m.mu.Unlock()
-		return api.ErrorResponse(id, "cannot stop session in state: "+s.Status)
+		return api.ErrorResponse(id, "cannot stop session in state: "+s.ExternalStatus())
 	}
 }
 

--- a/internal/pool/handlers_attach.go
+++ b/internal/pool/handlers_attach.go
@@ -157,6 +157,7 @@ func (m *Manager) handleDebugSlots(id any) api.Msg {
 		}
 		if s != nil {
 			slot["status"] = s.Status
+			slot["slotState"] = s.SlotState()
 			slot["claudeUUID"] = s.ClaudeUUID
 		}
 		slots = append(slots, slot)

--- a/internal/pool/handlers_lifecycle.go
+++ b/internal/pool/handlers_lifecycle.go
@@ -25,7 +25,7 @@ func (m *Manager) handleOffload(id any, req api.Msg) api.Msg {
 
 	if s.Status != StatusIdle {
 		log.Printf("[offload] session %s: rejected, status=%s (need idle)", s.ID, s.Status)
-		return api.ErrorResponse(id, "can only offload idle sessions (current: "+s.Status+")")
+		return api.ErrorResponse(id, "can only offload idle sessions (current: "+s.ExternalStatus()+")")
 	}
 
 	if s.Pinned {
@@ -284,7 +284,7 @@ func (m *Manager) handlePin(id any, req api.Msg) api.Msg {
 
 		return api.Response(id, "ok", api.Msg{
 			"sessionId": s.ID,
-			"status":    s.Status,
+			"status":    s.ExternalStatus(),
 		})
 	}
 
@@ -301,11 +301,9 @@ func (m *Manager) handlePin(id any, req api.Msg) api.Msg {
 	s.Pinned = true
 	s.PinExpiry = time.Now().Add(time.Duration(duration) * time.Second)
 
-	responseStatus := s.Status
 	if s.Status == StatusOffloaded || s.Status == StatusError {
 		prevStatus := s.Status
 		s.Status = StatusQueued
-		responseStatus = StatusQueued
 		m.queue = append([]*Session{s}, m.queue...)
 		m.broadcastStatus(s, prevStatus)
 		m.tryDequeueWithEviction(s, s.ID)
@@ -322,7 +320,7 @@ func (m *Manager) handlePin(id any, req api.Msg) api.Msg {
 
 	return api.Response(id, "ok", api.Msg{
 		"sessionId": s.ID,
-		"status":    responseStatus,
+		"status":    s.ExternalStatus(),
 	})
 }
 

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -187,7 +187,7 @@ func (m *Manager) broadcastStatus(s *Session, prevStatus string) {
 		"type":       "event",
 		"event":      "status",
 		"sessionId":  s.ID,
-		"status":     s.Status,
+		"status":     s.ExternalStatus(),
 		"prevStatus": prevStatus,
 	})
 }

--- a/internal/pool/session.go
+++ b/internal/pool/session.go
@@ -98,6 +98,33 @@ func (s *Session) ExternalStatus() string {
 	return s.Status
 }
 
+// SlotState returns the SPEC slot state for a live session.
+// Returns "" if the session doesn't occupy a slot.
+// SPEC: Slot States table — fresh, spawning, resuming, clearing, idle, processing, crashed.
+func (s *Session) SlotState() string {
+	if !s.IsLive() {
+		return ""
+	}
+	switch {
+	case s.PreWarmed && s.Status == StatusFresh && s.Recycled:
+		return "clearing"
+	case s.PreWarmed && s.Status == StatusFresh:
+		return "spawning"
+	case s.PreWarmed && s.Status == StatusIdle:
+		return "fresh"
+	case s.Status == StatusFresh && s.PendingResume != "":
+		return "resuming"
+	case s.Status == StatusFresh:
+		return "clearing"
+	case s.Status == StatusIdle:
+		return "idle"
+	case s.Status == StatusProcessing:
+		return "processing"
+	default:
+		return ""
+	}
+}
+
 // ToMsg converts a session to a protocol message.
 // Verbosity levels for session serialization (SPEC: Session Object table).
 const (


### PR DESCRIPTION
## Summary
- All API responses and broadcast events now use `s.ExternalStatus()` instead of `s.Status`, preventing internal `fresh` state from leaking to clients
- Extracted `SlotState()` method on Session — centralizes the internal→SPEC slot state mapping (was inline switch in `buildHealthResponse`)
- Added `slotState` field to debug slots output

**Confirmed bug fixed:** `handlePin` creating a new session with a fresh slot returned `"status": "fresh"` to the client. SPEC only allows: queued, idle, processing, offloaded, error, archived.

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./internal/...` passes
- [x] `make build` succeeds
- [x] Verified no remaining `s.Status` in API responses (only persistence + debug)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)