### PR TITLE
Fix premature idle detection and UUID discovery race

### DIFF
--- a/internal/pool/handlers_session.go
+++ b/internal/pool/handlers_session.go
@@ -44,6 +44,9 @@ func (m *Manager) handleStart(id any, req api.Msg) api.Msg {
 			sl.State = SlotProcessing
 			s.LastUsedAt = time.Now()
 			m.clearIdleSignals(sl.PID())
+			if sl.Term != nil {
+				sl.Term.resetIdleTracking()
+			}
 			m.deliverPrompt(sl, prompt)
 			s.PendingPrompt = ""
 		} else {
@@ -174,6 +177,9 @@ func (m *Manager) handleFollowup(id any, req api.Msg) api.Msg {
 		s.Status = StatusProcessing
 		sl.State = SlotProcessing
 		s.LastUsedAt = time.Now()
+		if sl.Term != nil {
+			sl.Term.resetIdleTracking()
+		}
 		m.deliverPrompt(sl, prompt)
 		m.broadcastStatus(s, StatusIdle)
 		m.savePoolState()

--- a/internal/pool/lifecycle.go
+++ b/internal/pool/lifecycle.go
@@ -156,6 +156,9 @@ func (m *Manager) clearSlot(sl *Slot) {
 	sl.State = SlotClearing
 
 	m.clearIdleSignals(sl.PID())
+	if sl.Term != nil {
+		sl.Term.resetIdleTracking()
+	}
 	m.deliverPrompt(sl, "/clear")
 }
 
@@ -332,9 +335,12 @@ func (m *Manager) watchIdleSignal(sl *Slot) {
 				return
 			}
 
-			// Check for Claude UUID from PID mapping
+			// Check for Claude UUID from PID mapping.
+			// Only discover UUID when the slot is processing or idle — during
+			// clearing/spawning/resuming, /clear generates intermediate UUIDs
+			// that don't correspond to the session's actual transcript.
 			sessionID := sl.SessionID
-			if sessionID != "" {
+			if sessionID != "" && (sl.State == SlotProcessing || sl.State == SlotIdle) {
 				if s := m.sessions[sessionID]; s != nil && s.ClaudeUUID == "" {
 					m.mu.Unlock()
 					if data, err := os.ReadFile(pidMapPath); err == nil {
@@ -378,7 +384,8 @@ func (m *Manager) watchIdleSignal(sl *Slot) {
 			lastSignalTS = ts
 			log.Printf("[idle-watch] slot %d: new signal (pid=%d): %s", sl.Index, pid, strings.TrimSpace(string(data)))
 
-			// Extract cwd and transcript from signal
+			// Extract cwd and transcript from signal.
+			// Only set UUID when processing/idle — clearing generates intermediate UUIDs.
 			if s := m.sessions[sl.SessionID]; s != nil {
 				if cwd, ok := sig["cwd"].(string); ok && cwd != "" && s.Cwd != cwd {
 					s.Cwd = cwd
@@ -387,10 +394,12 @@ func (m *Manager) watchIdleSignal(sl *Slot) {
 						"sessionId": s.ID, "changes": api.Msg{"cwd": cwd},
 					})
 				}
-				if transcript, ok := sig["transcript"].(string); ok && transcript != "" && s.ClaudeUUID == "" {
-					base := filepath.Base(transcript)
-					if uuid := strings.TrimSuffix(base, ".jsonl"); uuid != base {
-						s.ClaudeUUID = uuid
+				if (sl.State == SlotProcessing || sl.State == SlotIdle) && s.ClaudeUUID == "" {
+					if transcript, ok := sig["transcript"].(string); ok && transcript != "" {
+						base := filepath.Base(transcript)
+						if uuid := strings.TrimSuffix(base, ".jsonl"); uuid != base {
+							s.ClaudeUUID = uuid
+						}
 					}
 				}
 			}
@@ -456,6 +465,9 @@ func (m *Manager) transitionSlotToIdle(sl *Slot) {
 
 		log.Printf("[idle] slot %d session %s: delivering /resume %s", sl.Index, s.ID, uuid)
 		m.broadcastStatus(s, prevStatus)
+		if sl.Term != nil {
+			sl.Term.resetIdleTracking()
+		}
 		m.deliverPrompt(sl, "/resume "+uuid)
 		return
 	}
@@ -471,6 +483,9 @@ func (m *Manager) transitionSlotToIdle(sl *Slot) {
 		s.LastUsedAt = time.Now()
 		log.Printf("[idle] slot %d session %s: delivering pending prompt (%d chars)", sl.Index, s.ID, len(prompt))
 		m.broadcastStatus(s, prevStatus)
+		if sl.Term != nil {
+			sl.Term.resetIdleTracking()
+		}
 		m.deliverPrompt(sl, prompt)
 		return
 	}
@@ -780,6 +795,9 @@ func (m *Manager) claimSlotForQueued(sl *Slot, queued *Session) {
 	if sl.State == SlotFresh || sl.State == SlotIdle {
 		// Slot is ready — deliver immediately
 		m.clearIdleSignals(sl.PID())
+		if sl.Term != nil {
+			sl.Term.resetIdleTracking()
+		}
 
 		if queued.PendingResume != "" {
 			uuid := queued.PendingResume

--- a/internal/pool/typing.go
+++ b/internal/pool/typing.go
@@ -41,6 +41,17 @@ type sessionTerm struct {
 	lastIdleTransitionAt   time.Time // prevents duplicate idle transitions for same stable period
 }
 
+// resetIdleTracking invalidates stale idle detection state.
+// Must be called when a slot transitions to an active state (processing,
+// resuming, clearing) to prevent false idle transitions from stale content
+// timestamps. Must be called with the manager mutex held (not st.mu —
+// pollBufferInput reads these fields under the manager lock).
+func (st *sessionTerm) resetIdleTracking() {
+	st.contentChangedAt = time.Time{}
+	st.lastIdleTransitionAt = time.Time{}
+	st.lastOutputTime = time.Now()
+}
+
 func newSessionTerm(proc *ptyPkg.Process, cols, rows int) *sessionTerm {
 	if cols <= 0 {
 		cols = 80


### PR DESCRIPTION
## Summary

Fixes `start --block` and `wait` returning empty content — a bug where sessions became idle before their prompt was delivered, and UUID discovery picked up wrong intermediate UUIDs from the clear workflow.

## Root causes

1. **Premature idle detection**: when a slot transitioned from fresh to processing, `pollBufferInput`'s stale content/PTY-silent timestamps from the fresh phase triggered an immediate idle transition — before the prompt was even delivered. The session went idle→offloaded in the same second as binding.

2. **Wrong UUID from clear workflow**: each `/clear` generates a new Claude UUID. The PID mapping hook overwrites the UUID file each time. `watchIdleSignal` could discover an intermediate UUID that doesn't correspond to the session's actual transcript.

## Fix

- `resetIdleTracking()` on `sessionTerm` — zeroes content timestamps and resets PTY output time when a slot enters an active state (processing, resuming, clearing). Called from `handleStart`, `handleFollowup`, `clearSlot`, `transitionSlotToIdle`, and `claimSlotForQueued`.

- UUID discovery restricted to `SlotProcessing` and `SlotIdle` states — blocks reading stale PID mappings during clearing/spawning/resuming.

## Test plan

- [x] Unit tests pass
- [x] Manual: `start --block` returns content on fresh slot
- [x] Manual: `start --block` returns content after eviction (3 consecutive tests)
- [x] Integration: TestPool, TestSlots, TestProcessReuse, TestOffload, TestSession all pass (TestSession `cwd_updates` haiku flake is pre-existing)

🤖 Generated with [Claude Code](https://claude.ai/code)