### PR TITLE
Resolve PATH from login shell for spawned sessions

### DIFF
--- a/internal/pty/loginpath.go
+++ b/internal/pty/loginpath.go
@@ -1,0 +1,77 @@
+package pty
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	loginPATH     string
+	loginPATHOnce sync.Once
+)
+
+// getLoginShellPATH returns the PATH from a login shell, capturing what the
+// user's shell profile (.zprofile, .bash_profile, etc.) would set. This ensures
+// spawned processes inherit the same PATH as a normal terminal, even when the
+// daemon is launched from a non-login context (e.g., an Electron app or launchd).
+//
+// The result is cached — the login shell runs at most once per process.
+// On failure (timeout, broken profile), falls back to the current process PATH.
+func getLoginShellPATH() string {
+	loginPATHOnce.Do(func() {
+		loginPATH = resolveLoginPATH()
+	})
+	return loginPATH
+}
+
+func resolveLoginPATH() string {
+	if runtime.GOOS == "windows" {
+		return os.Getenv("PATH")
+	}
+
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, shell, "-lc", "echo $PATH")
+	out, err := cmd.Output()
+	if err != nil {
+		return os.Getenv("PATH")
+	}
+
+	result := strings.TrimSpace(string(out))
+	if result == "" {
+		return os.Getenv("PATH")
+	}
+	return result
+}
+
+// buildEnvWithLoginPATH returns a copy of os.Environ() with PATH replaced by
+// the login shell PATH.
+func buildEnvWithLoginPATH() []string {
+	loginPath := getLoginShellPATH()
+	currentPath := os.Getenv("PATH")
+
+	env := os.Environ()
+
+	// Only replace PATH if the login shell gave us something different
+	if loginPath != currentPath {
+		for i, e := range env {
+			if strings.HasPrefix(e, "PATH=") {
+				env[i] = "PATH=" + loginPath
+				break
+			}
+		}
+	}
+
+	return env
+}

--- a/internal/pty/loginpath_test.go
+++ b/internal/pty/loginpath_test.go
@@ -1,0 +1,64 @@
+package pty
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Prevents: spawned sessions missing Homebrew/user-installed tools because
+// the daemon was launched from a non-login context (e.g., Electron app, launchd)
+func TestGetLoginShellPATH(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("login shell PATH not applicable on Windows")
+	}
+
+	path := resolveLoginPATH()
+	if path == "" {
+		t.Fatal("resolveLoginPATH returned empty string")
+	}
+
+	// Should contain standard system paths
+	if !strings.Contains(path, "/usr/bin") {
+		t.Errorf("login PATH missing /usr/bin: %s", path)
+	}
+}
+
+// Prevents: buildEnvWithLoginPATH dropping or duplicating PATH entries
+func TestBuildEnvWithLoginPATH(t *testing.T) {
+	env := buildEnvWithLoginPATH()
+
+	var foundPath bool
+	pathCount := 0
+	for _, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			pathCount++
+			foundPath = true
+		}
+	}
+
+	if !foundPath {
+		t.Error("PATH not found in env")
+	}
+	if pathCount != 1 {
+		t.Errorf("expected exactly 1 PATH entry, got %d", pathCount)
+	}
+}
+
+// Prevents: login PATH resolution hanging on broken shell profiles
+func TestResolveLoginPATH_Timeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("login shell PATH not applicable on Windows")
+	}
+
+	// With a bogus shell, should fall back to current PATH
+	orig := os.Getenv("SHELL")
+	os.Setenv("SHELL", "/nonexistent/shell")
+	defer os.Setenv("SHELL", orig)
+
+	path := resolveLoginPATH()
+	if path != os.Getenv("PATH") {
+		t.Errorf("expected fallback to current PATH, got: %s", path)
+	}
+}

--- a/internal/pty/pty.go
+++ b/internal/pty/pty.go
@@ -48,8 +48,11 @@ func Spawn(opts SpawnOpts) (*Process, error) {
 	cmd := exec.Command("claude", args...)
 	cmd.Dir = opts.Cwd
 
-	// Build environment — strip vars that would cause issues in child sessions
-	env := os.Environ()
+	// Build environment with login shell PATH (ensures Homebrew etc. are available
+	// even when daemon is launched from non-login context like Electron or launchd)
+	env := buildEnvWithLoginPATH()
+
+	// Strip vars that would cause issues in child sessions
 	filtered := env[:0]
 	for _, e := range env {
 		if strings.HasPrefix(e, "CLAUDECODE=") || // Prevents "nested session" error


### PR DESCRIPTION
## Summary

- Add `loginpath.go` in `internal/pty/` — resolves PATH from a login shell at startup (`sync.Once`, 3s timeout, fallback to current PATH)
- Update `Spawn()` to use `buildEnvWithLoginPATH()` instead of raw `os.Environ()`, preserving existing env var filtering (CLAUDECODE, etc.)
- Fixes spawned sessions missing Homebrew and other tools when the daemon is launched from a non-login context (Electron, launchd)
- Adapted from the same pattern already merged in claude-term

## Test plan

- [x] `go build ./internal/...` passes
- [x] `go test ./internal/... -timeout 30s` passes (3 new tests in `loginpath_test.go`)
- [ ] Manual: launch daemon from Electron, verify `claude` sessions can find Homebrew-installed tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)