### PR TITLE
Debounce SIGWINCH in attach to prevent resize loops

### DIFF
--- a/cmd/claude-pool-cli/main.go
+++ b/cmd/claude-pool-cli/main.go
@@ -1006,12 +1006,18 @@ func doAttach(apiSock string, args []string) error {
 		}
 	}()
 
-	// Send initial resize to match local terminal size
+	// Send resize to match local terminal size.
+	// Tracks last sent size to prevent resize loops in nested PTY environments.
+	var lastW, lastH int
 	sendResize := func() {
 		w, h, err := term.GetSize(fd)
 		if err != nil {
 			return
 		}
+		if w == lastW && h == lastH {
+			return
+		}
+		lastW, lastH = w, h
 		rc, err := dial(apiSock)
 		if err != nil {
 			return


### PR DESCRIPTION
## Summary

- Tracks last sent terminal size in attach's SIGWINCH handler
- Skips resize events when size hasn't changed, preventing infinite loops in nested PTY environments

## Test plan

- [x] Builds clean
- [ ] Manual: attach from Open Cockpit terminal tab — should not loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)