### PR TITLE
Fix CLI daemon discovery and init-when-running

### DIFF
--- a/cmd/claude-pool-cli/main.go
+++ b/cmd/claude-pool-cli/main.go
@@ -267,15 +267,10 @@ func doInit(poolName string, args []string, jsonMode bool) error {
 
 	sock := filepath.Join(dir, "api.sock")
 
-	// Check if daemon is already running. If so, skip spawn and just send
-	// the init command — handles the case where daemon survived a restart
-	// or was started manually but never received init.
+	// Try connecting to an existing daemon. If it's already running,
+	// skip spawn and just send init (handles manual start or survived restart).
 	initSuccess := false
-	daemonAlreadyRunning := false
-	if c, err := net.DialTimeout("unix", sock, time.Second); err == nil {
-		c.Close()
-		daemonAlreadyRunning = true
-	}
+	existingConn, _ := dial(sock)
 
 	// Parse args for config updates and init message
 	var size int
@@ -355,7 +350,7 @@ func doInit(poolName string, args []string, jsonMode bool) error {
 		return fmt.Errorf("cannot write config: %w", err)
 	}
 
-	if !daemonAlreadyRunning {
+	if existingConn == nil {
 		// Start daemon (detached — must not inherit CLI's stdio pipes).
 		// Daemon handles its own logging to daemon.log. Don't pipe its
 		// stdout/stderr anywhere — the CLI must not hold open file descriptors
@@ -377,23 +372,23 @@ func doInit(poolName string, args []string, jsonMode bool) error {
 
 		// Wait for socket to appear
 		deadline := time.Now().Add(10 * time.Second)
+		var statErr error
 		for time.Now().Before(deadline) {
-			if _, err := os.Stat(sock); err == nil {
+			if _, statErr = os.Stat(sock); statErr == nil {
 				break
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
-		if _, err := os.Stat(sock); err != nil {
+		if statErr != nil {
 			return fmt.Errorf("daemon socket never appeared at %s", sock)
 		}
-	}
 
-	// Connect and send init
-	c, err := dial(sock)
-	if err != nil {
-		return fmt.Errorf("cannot connect to daemon: %w", err)
+		existingConn, err = dial(sock)
+		if err != nil {
+			return fmt.Errorf("cannot connect to daemon: %w", err)
+		}
 	}
-	defer c.close()
+	defer existingConn.close()
 
 	initMsg := map[string]any{"type": "init"}
 	if size > 0 {
@@ -403,7 +398,7 @@ func doInit(poolName string, args []string, jsonMode bool) error {
 		initMsg["noRestore"] = true
 	}
 
-	resp, err := c.send(initMsg)
+	resp, err := existingConn.send(initMsg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- **Sibling binary discovery**: `daemonBin()` now resolves symlinks and checks for `claude-pool` next to `claude-pool-cli` as a 3rd fallback (after env var and PATH). Fixes "daemon binary not found" when CLI is installed via `make install` but daemon isn't separately on PATH.
- **Init with running daemon**: `init` no longer hard-fails when the daemon socket is reachable. It skips spawning and sends the init command to the existing daemon. Fixes the contradictory "already running" + "not initialized" state.

## Test plan

- [x] `make build` succeeds
- [x] `go test ./internal/...` passes
- [x] Manual test: `./bin/claude-pool-cli init --size 2` works without daemon on PATH
- [x] Manual test: `health`, `ls` work after init
- [x] Manual test: double `init` correctly returns "pool already initialized" from daemon
- [ ] Integration tests (need real Claude sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)