### PR TITLE
Bump idle detection threshold from 1s to 2s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,8 @@ Two complementary systems detect slot state transitions:
 
 1. **Screen content monitoring** (`typing.go` → `pollBufferInput`, runs on **slots**):
    - Content above prompt changing → slot processing
-   - Content stable 1s → slot idle (calls `transitionSlotToIdle()`)
-   - PTY silent 1s → slot idle (fallback)
+   - Content stable 2s → slot idle (calls `transitionSlotToIdle()`)
+   - PTY silent 2s → slot idle (fallback)
    - Pending input detection → surfaced to session via `session.PendingInput`
 
 2. **Hook signal watcher** (`lifecycle.go` → `watchIdleSignal`):

--- a/internal/pool/typing.go
+++ b/internal/pool/typing.go
@@ -186,7 +186,7 @@ func (m *Manager) pollBufferInput() {
 	}
 	m.mu.Unlock()
 
-	const idleThreshold = 1 * time.Second
+	const idleThreshold = 2 * time.Second
 
 	for _, item := range toPoll {
 		content := contentAbovePrompt(item.rendered)


### PR DESCRIPTION
## Summary

- False idle transitions during long tool calls (Agent, WebFetch) caused `wait` to return prematurely with intermediate output
- Root cause: screen content stable for >1s while Claude waits for tool result → falsely declared idle
- Observed 4 false idle transitions in ~20s during a Zotero pipeline session running sub-agents

## Test plan

- [x] Unit tests pass
- [ ] Manual: dispatch a Zotero pipeline item and `wait` — should return only when truly done

🤖 Generated with [Claude Code](https://claude.com/claude-code)