### PR TITLE
Track UUID from session-clear signals

### DIFF
--- a/internal/pool/lifecycle.go
+++ b/internal/pool/lifecycle.go
@@ -383,10 +383,12 @@ func (m *Manager) watchIdleSignal(sl *Slot) {
 
 			trigger, _ := sig["trigger"].(string)
 
-			// Track UUID on the slot from session-start signals.
-			// This runs even when no session is bound, so the UUID is
-			// available when a session is later bound via bindSession.
-			if trigger == "session-start" {
+			// Track UUID on the slot from session-start and session-clear
+			// signals. Both carry the current transcript UUID. The clear
+			// workflow fires session-clear (not session-start) for each
+			// step, so we must track both to ensure LastClaudeUUID is set
+			// when bindSession runs.
+			if trigger == "session-start" || trigger == "session-clear" {
 				if transcript, ok := sig["transcript"].(string); ok && transcript != "" {
 					base := filepath.Base(transcript)
 					if uuid := strings.TrimSuffix(base, ".jsonl"); uuid != base {


### PR DESCRIPTION
## Summary

`LastClaudeUUID` was only updated on `session-start` signals, but the clear workflow fires `session-clear` signals. After `clearSlot` reset `LastClaudeUUID`, it stayed empty because no `session-start` fired during clearing.

Fix: update on both `session-start` and `session-clear` (both carry the transcript UUID).

## Test plan

- [x] All 4 initial slots get UUIDs immediately on fresh pool init
- [x] Capture returns real content (6-10 assistant messages per session)
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)