### PR TITLE
Fix UUID tracking: sequential spawn + session-pids fallback

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,5 @@
   "license": "MIT",
   "name": "claude-pool",
   "repository": "https://github.com/EliasSchlie/claude-pool",
-  "version": "0.1.40"
+  "version": "0.1.41"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,8 @@ Two complementary systems detect slot state transitions:
 
 1. **Screen content monitoring** (`typing.go` → `pollBufferInput`, runs on **slots**):
    - Content above prompt changing → slot processing
-   - Content stable 3s → slot idle (calls `transitionSlotToIdle()`)
-   - PTY silent 3s → slot idle (fallback)
+   - Content stable 5s → slot idle (calls `transitionSlotToIdle()`)
+   - PTY silent 5s → slot idle (fallback)
    - Pending input detection → surfaced to session via `session.PendingInput`
 
 2. **Hook signal watcher** (`lifecycle.go` → `watchIdleSignal`):

--- a/hooks/pid-registry.sh
+++ b/hooks/pid-registry.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 REGISTRY_DIR="${HOME}/.claude-pool/pid-registry"
-mkdir -p "$REGISTRY_DIR"
+[ -d "$REGISTRY_DIR" ] || mkdir -p "$REGISTRY_DIR"
 
 input=""
 read -t 1 -r input 2>/dev/null || true
@@ -24,11 +24,10 @@ session_id=$(echo "$input" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\
 # $PPID is the Claude process that spawned this hook
 echo "$session_id" > "$REGISTRY_DIR/$PPID"
 
-# Also write to pool-local session-pids if in a pool session.
-# This is the authoritative UUID for the session's actual work
-# (unlike SessionStart which fires during /clear with intermediate UUIDs).
+# Write to pool-local session-pids — authoritative UUID for the session's
+# actual work (unlike SessionStart which fires during /clear with intermediate UUIDs).
 if [ -n "${CLAUDE_POOL_DIR:-}" ]; then
-    mkdir -p "$CLAUDE_POOL_DIR/session-pids"
+    [ -d "$CLAUDE_POOL_DIR/session-pids" ] || mkdir -p "$CLAUDE_POOL_DIR/session-pids"
     echo "$session_id" > "$CLAUDE_POOL_DIR/session-pids/$PPID"
 fi
 

--- a/hooks/pid-registry.sh
+++ b/hooks/pid-registry.sh
@@ -24,6 +24,14 @@ session_id=$(echo "$input" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\
 # $PPID is the Claude process that spawned this hook
 echo "$session_id" > "$REGISTRY_DIR/$PPID"
 
+# Also write to pool-local session-pids if in a pool session.
+# This is the authoritative UUID for the session's actual work
+# (unlike SessionStart which fires during /clear with intermediate UUIDs).
+if [ -n "${CLAUDE_POOL_DIR:-}" ]; then
+    mkdir -p "$CLAUDE_POOL_DIR/session-pids"
+    echo "$session_id" > "$CLAUDE_POOL_DIR/session-pids/$PPID"
+fi
+
 # Clean up stale entries ~1 in 20 invocations (avoid hot-path overhead)
 if (( RANDOM % 20 == 0 )); then
     for f in "$REGISTRY_DIR"/*; do

--- a/hooks/pid-registry.sh
+++ b/hooks/pid-registry.sh
@@ -24,8 +24,9 @@ session_id=$(echo "$input" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\
 # $PPID is the Claude process that spawned this hook
 echo "$session_id" > "$REGISTRY_DIR/$PPID"
 
-# Write to pool-local session-pids — authoritative UUID for the session's
-# actual work (unlike SessionStart which fires during /clear with intermediate UUIDs).
+# Write to pool-local session-pids. Serves as fallback UUID source when
+# SessionStart hooks don't fire (concurrent spawn race). Cleared by the
+# daemon on slot clear, so stale UUIDs don't persist across sessions.
 if [ -n "${CLAUDE_POOL_DIR:-}" ]; then
     [ -d "$CLAUDE_POOL_DIR/session-pids" ] || mkdir -p "$CLAUDE_POOL_DIR/session-pids"
     echo "$session_id" > "$CLAUDE_POOL_DIR/session-pids/$PPID"

--- a/internal/pool/handlers_pool.go
+++ b/internal/pool/handlers_pool.go
@@ -119,6 +119,11 @@ func (m *Manager) handleInit(id any, req api.Msg) api.Msg {
 		log.Printf("[init] spawning %d fresh slots", remaining)
 	}
 
+	// Start typing poller early — the wait loop below may trigger
+	// keepFresh → clearSlot, which needs the poller to detect clearing
+	// step completions.
+	m.startTypingPoller()
+
 	// Spawn slot 0 first and wait for it to become ready before spawning
 	// the rest. This ensures the first Claude process initializes its
 	// plugin cache, accepts the workspace trust prompt, etc. without
@@ -156,7 +161,7 @@ func (m *Manager) handleInit(id any, req api.Msg) api.Msg {
 
 	log.Printf("[init] pool initialized: %d slots", size)
 	m.savePoolState()
-	m.startTypingPoller()
+	// Typing poller already started above (before wait loop).
 	m.startMaintenanceLoop()
 
 	return m.buildHealthResponse(id)

--- a/internal/pool/handlers_pool.go
+++ b/internal/pool/handlers_pool.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"log"
+	"os"
 	"time"
 
 	"github.com/EliasSchlie/claude-pool/internal/api"
@@ -234,6 +235,11 @@ func (m *Manager) handleDestroy(id any, req api.Msg) api.Msg {
 			}
 			s.SlotIndex = -1
 			s.PendingInput = ""
+		}
+		// Clean up PID-keyed files before killing the process.
+		if sl.PID() > 0 {
+			os.Remove(m.paths.SessionPID(sl.PID()))
+			os.Remove(m.paths.IdleSignal(sl.PID()))
 		}
 		sl.SessionID = ""
 		log.Printf("[destroy] killing slot %d (pid=%d)", sl.Index, sl.PID())

--- a/internal/pool/handlers_pool.go
+++ b/internal/pool/handlers_pool.go
@@ -75,7 +75,7 @@ func (m *Manager) handleInit(id any, req api.Msg) api.Msg {
 		liveSessions, offloadedSessions = m.loadPoolState()
 	}
 
-	// Restore live sessions into slots
+	// Bind sessions to slots (but don't spawn yet).
 	restored := 0
 	log.Printf("[init] restoring state: %d live, %d offloaded sessions from pool.json", len(liveSessions), len(offloadedSessions))
 	for _, s := range liveSessions {
@@ -93,11 +93,9 @@ func (m *Manager) handleInit(id any, req api.Msg) api.Msg {
 			s.PendingResume = s.ClaudeUUID
 		}
 		log.Printf("[init] restoring live session %s into slot %d (resume=%v)", s.ID, sl.Index, s.PendingResume != "")
-		m.spawnSlot(sl)
 		restored++
 	}
 
-	// Restore offloaded sessions into remaining slots
 	for _, s := range offloadedSessions {
 		if restored >= size {
 			log.Printf("[init] session %s exceeds pool size, keeping offloaded", s.ID)
@@ -113,44 +111,45 @@ func (m *Manager) handleInit(id any, req api.Msg) api.Msg {
 			s.PendingResume = s.ClaudeUUID
 		}
 		log.Printf("[init] restoring offloaded session %s into slot %d (resume=%v)", s.ID, sl.Index, s.PendingResume != "")
-		m.spawnSlot(sl)
 		restored++
 	}
 
-	// Fill remaining slots with fresh processes.
-	// Spawn the first one and wait for it to become idle before spawning the
-	// rest — ensures workspace trust prompt is accepted and cached.
 	remaining := size - restored
 	if remaining > 0 {
 		log.Printf("[init] spawning %d fresh slots", remaining)
-		sl := m.slots[restored]
-		m.spawnSlot(sl)
+	}
 
-		if remaining > 1 {
-			m.mu.Unlock()
-			// Wait for first slot to become ready
-			deadline := time.After(60 * time.Second)
-		waitLoop:
-			for {
-				m.mu.Lock()
-				if sl.State == SlotFresh || sl.State == SlotIdle {
-					m.mu.Unlock()
-					break
-				}
-				ch := m.statusNotify
-				m.mu.Unlock()
-				select {
-				case <-deadline:
-					log.Printf("[init] first slot timed out waiting for ready")
-					break waitLoop
-				case <-ch:
-				}
-			}
+	// Spawn slot 0 first and wait for it to become ready before spawning
+	// the rest. This ensures the first Claude process initializes its
+	// plugin cache, accepts the workspace trust prompt, etc. without
+	// racing against other instances. Without this, concurrent Claude
+	// startups cause plugin hooks to fail for most sessions.
+	m.spawnSlot(m.slots[0])
+
+	if size > 1 {
+		m.mu.Unlock()
+		deadline := time.After(60 * time.Second)
+	waitLoop:
+		for {
 			m.mu.Lock()
-			log.Printf("[init] first slot ready, spawning %d more", remaining-1)
+			sl := m.slots[0]
+			if sl.State == SlotFresh || sl.State == SlotIdle {
+				m.mu.Unlock()
+				break
+			}
+			ch := m.statusNotify
+			m.mu.Unlock()
+			select {
+			case <-deadline:
+				log.Printf("[init] first slot timed out waiting for ready")
+				break waitLoop
+			case <-ch:
+			}
 		}
+		m.mu.Lock()
+		log.Printf("[init] first slot ready, spawning %d more", size-1)
 
-		for i := restored + 1; i < size; i++ {
+		for i := 1; i < size; i++ {
 			m.spawnSlot(m.slots[i])
 		}
 	}

--- a/internal/pool/lifecycle.go
+++ b/internal/pool/lifecycle.go
@@ -397,7 +397,7 @@ func (m *Manager) watchIdleSignal(sl *Slot) {
 				}
 			}
 
-			// Extract cwd and transcript from signal.
+			// Extract cwd and update session UUID from signal.
 			if s := m.sessions[sl.SessionID]; s != nil {
 				if cwd, ok := sig["cwd"].(string); ok && cwd != "" && s.Cwd != cwd {
 					s.Cwd = cwd

--- a/internal/pool/lifecycle.go
+++ b/internal/pool/lifecycle.go
@@ -364,6 +364,22 @@ func (m *Manager) watchIdleSignal(sl *Slot) {
 			// Read signal file
 			data, err := os.ReadFile(signalPath)
 			if err != nil {
+				// Fallback: if no signal file, try session-pids/<PID>.
+				// SessionStart hooks sometimes don't fire when many Claude
+				// sessions spawn simultaneously. The PreToolUse Bash hook
+				// (pid-registry.sh) writes the UUID reliably during processing.
+				if sl.LastClaudeUUID == "" {
+					if pidData, pidErr := os.ReadFile(m.paths.SessionPID(pid)); pidErr == nil {
+						if uuid := strings.TrimSpace(string(pidData)); uuid != "" {
+							sl.LastClaudeUUID = uuid
+							log.Printf("[idle-watch] slot %d: UUID from session-pids (pid=%d): %s", sl.Index, pid, uuid)
+							if s := m.sessions[sl.SessionID]; s != nil && s.ClaudeUUID != uuid {
+								log.Printf("[idle-watch] slot %d session %s: UUID %s → %s (from pid-registry)", sl.Index, s.ID, s.ClaudeUUID, uuid)
+								s.ClaudeUUID = uuid
+							}
+						}
+					}
+				}
 				m.mu.Unlock()
 				continue
 			}

--- a/internal/pool/typing.go
+++ b/internal/pool/typing.go
@@ -186,7 +186,7 @@ func (m *Manager) pollBufferInput() {
 	}
 	m.mu.Unlock()
 
-	const idleThreshold = 3 * time.Second
+	const idleThreshold = 5 * time.Second
 
 	for _, item := range toPoll {
 		content := contentAbovePrompt(item.rendered)


### PR DESCRIPTION
## Summary

Three fixes for reliable UUID discovery:

1. **Idle threshold 3s → 5s** (typing.go): All false evictions occurred at 4s (3s + detection delay), shortest real sessions take 6s.

2. **Sequential slot spawning** (handlers_pool.go): When multiple Claude Code sessions start simultaneously, their plugin hooks fail to load. Root cause: Claude Code's plugin initialization races under concurrent startup. Fix: spawn first slot, wait for ready, then spawn the rest. This was already done for fresh pools (trust prompt caching) but not for the restore path.
   - Result: 6/6 slots get signals (was 1/6)

3. **Session-pids fallback** (lifecycle.go): When SessionStart hooks still don't fire (edge cases), fall back to reading the UUID from `session-pids/<PID>` written by the PreToolUse Bash hook (pid-registry.sh). Both paths log clearly.

4. **Typing poller before wait loop** (handlers_pool.go): The sequential spawn wait loop can trigger keep-fresh → clearSlot, which needs the typing poller to detect clearing step completions. Start the poller before the wait, not after.

5. **Pool-local session-pids write** (pid-registry.sh): PreToolUse Bash hook now also writes UUID to `$CLAUDE_POOL_DIR/session-pids/$PPID` (in addition to global registry).

## Root Cause Analysis

Claude Code doesn't reliably fire plugin hooks when multiple instances start simultaneously. Tested with controlled experiments:
- Fresh pool (sequential spawn): 4/4 signals
- Restored pool (simultaneous spawn): 1/4 signals  
- Restored pool (sequential spawn, this fix): 4/4 signals
- Full 6-slot pool with fix: 6/6 signals

## Test plan

- [x] Unit tests pass
- [x] Build succeeds
- [x] Controlled experiment: fresh pool signals work (4/4)
- [x] Controlled experiment: simultaneous spawn fails (1/4)
- [x] Sequential spawn fix: 4/4 signals on restore
- [x] Full 6-slot pool: 6/6 signals, 5/5 sessions with UUIDs
- [x] Typing poller deadlock fixed (clearing workflow completes)
- [x] Fallback logging visible in daemon logs
- [x] No false idle evictions with 5s threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)