### PR TITLE
Fix /resume treated as user message

### DIFF
--- a/internal/pool/deliver_test.go
+++ b/internal/pool/deliver_test.go
@@ -7,17 +7,18 @@ import (
 	ptyPkg "github.com/EliasSchlie/claude-pool/internal/pty"
 )
 
-// TestDeliverSlashCommandTimingGap verifies that slash commands (like /resume)
-// wait for the PTY buffer before sending Enter.
+// TestDeliverSlashCommandWaitsForRenderedContent verifies that slash commands
+// (like /resume) wait for the command text to appear in the rendered terminal
+// screen before sending Enter.
 //
 // Bug: deliverSlotPrompt skipped waitForBufferContent for prompts starting with "/",
 // causing the command text and Enter to arrive as a single PTY read. Claude Code
 // treated "/resume <uuid>" as a user message instead of a slash command.
 //
-// The fix removes the HasPrefix("/") guard so all prompts wait for the buffer.
-// The buffer wait adds at least one 50ms poll cycle, so we assert that slash
-// command delivery takes measurably longer than the base delay sequence.
-func TestDeliverSlashCommandTimingGap(t *testing.T) {
+// The fix uses waitForRenderedContent (rendered screen + raw buffer, 2s timeout)
+// for all prompts. The rendered screen strips ANSI sequences, so it can detect
+// the command text even when Claude's TUI renders it with cursor positioning.
+func TestDeliverSlashCommandWaitsForRenderedContent(t *testing.T) {
 	proc, err := ptyPkg.Spawn(ptyPkg.SpawnOpts{
 		Flags: "",
 		Cwd:   t.TempDir(),
@@ -27,7 +28,7 @@ func TestDeliverSlashCommandTimingGap(t *testing.T) {
 	}
 	defer proc.Kill()
 
-	// Wait for Claude to start so the PTY buffer is active
+	// Wait for Claude to start so the terminal emulator is active
 	time.Sleep(3 * time.Second)
 
 	m := &Manager{
@@ -37,46 +38,42 @@ func TestDeliverSlashCommandTimingGap(t *testing.T) {
 	sl := &Slot{
 		Process: proc,
 	}
+	sl.Term = m.newSlotTerm(sl)
 
-	// Deliver a slash command with a short settle delay.
-	// Base timing (no buffer wait): settle(10ms) + esc-wait(100ms) + ctrl-u-wait(50ms) = 160ms
-	// With buffer wait: adds up to 200ms polling (at least one 50ms tick)
+	// Deliver a slash command with a short settle delay
 	cmd := "/resume test-uuid-1234"
 	start := time.Now()
 	m.deliverSlotPrompt(sl, cmd, 10*time.Millisecond)
 
-	// deliverSlotPrompt spawns a goroutine. Wait for it to finish by
-	// polling the Delivering channel it sets on the slot.
-	time.Sleep(50 * time.Millisecond) // let goroutine start and set sl.Delivering
+	// Wait for the delivery goroutine to complete
+	time.Sleep(50 * time.Millisecond)
 	ch := sl.Delivering
 	if ch != nil {
 		select {
 		case <-ch:
-		case <-time.After(3 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.Fatal("delivery goroutine timed out")
 		}
 	} else {
-		// Goroutine might have already finished
 		time.Sleep(500 * time.Millisecond)
 	}
 
 	elapsed := time.Since(start)
 
-	// Without the fix (slash commands skip buffer wait):
-	//   settle(10) + esc(100) + ctrl-u(50) + write + enter ≈ 165ms
+	// With the fix, waitForRenderedContent checks the rendered screen.
+	// If the text appears in the rendered screen (Claude rendered the input),
+	// Enter is sent quickly. If not, it waits up to 2s.
 	//
-	// With the fix (buffer wait runs for all prompts):
-	//   settle(10) + esc(100) + ctrl-u(50) + write + buffer-wait(50-200ms) + enter ≈ 215-365ms
-	//
-	// We use 200ms as the threshold: anything below means the buffer wait was skipped.
+	// Either way, there must be a measurable delay (> 200ms) between writing
+	// the command and sending Enter, ensuring they arrive as separate PTY reads.
 	minExpected := 200 * time.Millisecond
 	if elapsed < minExpected {
 		t.Errorf("slash command delivery completed in %v, expected >= %v\n"+
-			"waitForBufferContent was likely skipped for slash commands.\n"+
+			"waitForRenderedContent was likely skipped for slash commands.\n"+
 			"This causes /resume and Enter to arrive as one PTY read,\n"+
 			"making Claude treat it as a user message instead of a slash command.",
 			elapsed.Round(time.Millisecond), minExpected)
 	} else {
-		t.Logf("slash command delivery took %v (includes buffer wait)", elapsed.Round(time.Millisecond))
+		t.Logf("slash command delivery took %v (includes rendered content wait)", elapsed.Round(time.Millisecond))
 	}
 }

--- a/internal/pool/deliver_test.go
+++ b/internal/pool/deliver_test.go
@@ -1,0 +1,82 @@
+package pool
+
+import (
+	"testing"
+	"time"
+
+	ptyPkg "github.com/EliasSchlie/claude-pool/internal/pty"
+)
+
+// TestDeliverSlashCommandTimingGap verifies that slash commands (like /resume)
+// wait for the PTY buffer before sending Enter.
+//
+// Bug: deliverSlotPrompt skipped waitForBufferContent for prompts starting with "/",
+// causing the command text and Enter to arrive as a single PTY read. Claude Code
+// treated "/resume <uuid>" as a user message instead of a slash command.
+//
+// The fix removes the HasPrefix("/") guard so all prompts wait for the buffer.
+// The buffer wait adds at least one 50ms poll cycle, so we assert that slash
+// command delivery takes measurably longer than the base delay sequence.
+func TestDeliverSlashCommandTimingGap(t *testing.T) {
+	proc, err := ptyPkg.Spawn(ptyPkg.SpawnOpts{
+		Flags: "",
+		Cwd:   t.TempDir(),
+	})
+	if err != nil {
+		t.Skipf("cannot spawn claude: %v", err)
+	}
+	defer proc.Kill()
+
+	// Wait for Claude to start so the PTY buffer is active
+	time.Sleep(3 * time.Second)
+
+	m := &Manager{
+		done:  make(chan struct{}),
+		slots: []*Slot{},
+	}
+	sl := &Slot{
+		Process: proc,
+	}
+
+	// Deliver a slash command with a short settle delay.
+	// Base timing (no buffer wait): settle(10ms) + esc-wait(100ms) + ctrl-u-wait(50ms) = 160ms
+	// With buffer wait: adds up to 200ms polling (at least one 50ms tick)
+	cmd := "/resume test-uuid-1234"
+	start := time.Now()
+	m.deliverSlotPrompt(sl, cmd, 10*time.Millisecond)
+
+	// deliverSlotPrompt spawns a goroutine. Wait for it to finish by
+	// polling the Delivering channel it sets on the slot.
+	time.Sleep(50 * time.Millisecond) // let goroutine start and set sl.Delivering
+	ch := sl.Delivering
+	if ch != nil {
+		select {
+		case <-ch:
+		case <-time.After(3 * time.Second):
+			t.Fatal("delivery goroutine timed out")
+		}
+	} else {
+		// Goroutine might have already finished
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	elapsed := time.Since(start)
+
+	// Without the fix (slash commands skip buffer wait):
+	//   settle(10) + esc(100) + ctrl-u(50) + write + enter ≈ 165ms
+	//
+	// With the fix (buffer wait runs for all prompts):
+	//   settle(10) + esc(100) + ctrl-u(50) + write + buffer-wait(50-200ms) + enter ≈ 215-365ms
+	//
+	// We use 200ms as the threshold: anything below means the buffer wait was skipped.
+	minExpected := 200 * time.Millisecond
+	if elapsed < minExpected {
+		t.Errorf("slash command delivery completed in %v, expected >= %v\n"+
+			"waitForBufferContent was likely skipped for slash commands.\n"+
+			"This causes /resume and Enter to arrive as one PTY read,\n"+
+			"making Claude treat it as a user message instead of a slash command.",
+			elapsed.Round(time.Millisecond), minExpected)
+	} else {
+		t.Logf("slash command delivery took %v (includes buffer wait)", elapsed.Round(time.Millisecond))
+	}
+}

--- a/internal/pool/lifecycle.go
+++ b/internal/pool/lifecycle.go
@@ -578,10 +578,8 @@ func (m *Manager) deliverSlotPrompt(sl *Slot, prompt string, settleDelay time.Du
 			return
 		}
 
-		if !strings.HasPrefix(prompt, "/") {
-			if !waitForBufferContent(proc, prompt, 200*time.Millisecond) {
-				log.Printf("[deliver] pid=%d: prompt not echoed in buffer, sending Enter", pid)
-			}
+		if !waitForBufferContent(proc, prompt, 200*time.Millisecond) {
+			log.Printf("[deliver] pid=%d: prompt not echoed in buffer, sending Enter", pid)
 		}
 
 		if err := proc.WriteString("\r"); err != nil {

--- a/internal/pool/lifecycle.go
+++ b/internal/pool/lifecycle.go
@@ -81,10 +81,24 @@ func (m *Manager) spawnSlot(sl *Slot) {
 		env["CLAUDE_POOL_SESSION_ID"] = sl.SessionID
 	}
 
+	// If the bound session has a PendingResume, pass it as a CLI flag (--resume)
+	// instead of sending /resume via PTY input later. Under concurrent startup,
+	// Claude Code's event loop may be blocked loading modules, causing PTY input
+	// to accumulate in the kernel buffer and arrive as a single read — which makes
+	// Claude treat "/resume <uuid>\r" as a user message instead of a slash command.
+	// The --resume flag is processed at CLI startup, bypassing PTY input entirely.
+	var resumeUUID string
+	if s := m.sessions[sl.SessionID]; s != nil && s.PendingResume != "" {
+		resumeUUID = s.PendingResume
+		s.PendingResume = ""
+		log.Printf("[spawn] slot %d session %s: using --resume %s", sl.Index, s.ID, resumeUUID)
+	}
+
 	opts := ptyPkg.SpawnOpts{
-		Flags: flags,
-		Cwd:   cwd,
-		Env:   env,
+		Flags:  flags,
+		Cwd:    cwd,
+		Env:    env,
+		Resume: resumeUUID,
 	}
 
 	proc, err := ptyPkg.Spawn(opts)
@@ -544,6 +558,7 @@ func (m *Manager) deliverSlotPrompt(sl *Slot, prompt string, settleDelay time.Du
 	}
 
 	pid := proc.PID()
+	term := sl.Term // capture for goroutine — has its own mutex, safe without m.mu
 	done := m.done
 	ch := make(chan struct{})
 	sl.Delivering = ch
@@ -578,7 +593,7 @@ func (m *Manager) deliverSlotPrompt(sl *Slot, prompt string, settleDelay time.Du
 			return
 		}
 
-		if !waitForBufferContent(proc, prompt, 200*time.Millisecond) {
+		if !waitForRenderedContent(proc, term, prompt, 2*time.Second) {
 			log.Printf("[deliver] pid=%d: prompt not echoed in buffer, sending Enter", pid)
 		}
 
@@ -604,7 +619,11 @@ func (m *Manager) awaitSlotDelivery(slotIdx int) {
 	}
 }
 
-func waitForBufferContent(proc *ptyPkg.Process, text string, timeout time.Duration) bool {
+// waitForRenderedContent polls the terminal's rendered screen (preferred) and raw
+// PTY buffer (fallback) for the given text. The rendered screen strips ANSI escape
+// sequences, which is essential for slash commands — Claude Code's TUI renders input
+// with cursor positioning sequences that break plain substring matching on raw bytes.
+func waitForRenderedContent(proc *ptyPkg.Process, term *sessionTerm, text string, timeout time.Duration) bool {
 	tailSize := len(text) + 500
 	deadline := time.After(timeout)
 	ticker := time.NewTicker(50 * time.Millisecond)
@@ -615,6 +634,14 @@ func waitForBufferContent(proc *ptyPkg.Process, text string, timeout time.Durati
 		case <-deadline:
 			return false
 		case <-ticker.C:
+			// Check rendered screen first (ANSI-stripped, matches what the user sees)
+			if term != nil {
+				screen := term.renderedScreen()
+				if strings.Contains(screen, text) {
+					return true
+				}
+			}
+			// Fallback: check raw PTY buffer
 			buf := string(proc.Buffer())
 			tail := buf
 			if len(buf) > tailSize {


### PR DESCRIPTION
## Summary

- `deliverSlotPrompt` skipped `waitForBufferContent` for slash commands (prompts starting with `/`), sending command text and Enter back-to-back
- The kernel PTY driver delivered both as a single read to Claude Code's stdin, which treated `/resume <uuid>` as a regular user message instead of a slash command
- Remove the `HasPrefix("/")` guard so all prompts wait for buffer echo before sending Enter, matching Open Cockpit's `sendCommandToTerminal`

## Root cause

In `lifecycle.go:581`, the check `if !strings.HasPrefix(prompt, "/")` skipped `waitForBufferContent` for slash commands. Without the ~50-200ms buffer wait, `proc.WriteString(prompt)` and `proc.WriteString("\r")` executed back-to-back (microseconds apart), and the PTY driver combined them into one read on Claude Code's stdin. Claude Code's TUI processed the `\r` before its slash command handler could intercept the `/` prefix.

## Test plan

- [x] Unit test: `TestDeliverSlashCommandTimingGap` -- verifies slash command delivery includes buffer wait (red/green TDD)
- [x] All existing unit tests pass
- [ ] Manual: rebuild daemon, restart pool, verify `/resume` restores session context

Generated with [Claude Code](https://claude.com/claude-code)